### PR TITLE
[Feature] Add the user password change api

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/UserController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/UserController.java
@@ -125,4 +125,19 @@ public class UserController {
     public R<Void> delete(@PathVariable Integer[] userIds) {
         return userService.deleteUserByIds(userIds) > 0 ? R.succeed() : R.failed();
     }
+
+    /**
+     * Changes a user's password.
+     *
+     * @param user the user object containing the new password
+     * @return a response entity indicating success or failure
+     */
+    @SaCheckPermission("system:user:change:password")
+    @PostMapping("/change/password")
+    public R<Void> changePassword(@Validated @RequestBody User user) {
+        if (userService.getUserById(user.getId()) == null) {
+            return R.failed(USER_NOT_EXIST);
+        }
+        return userService.changePassword(user) ? R.succeed() : R.failed();
+    }
 }

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/UserService.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/UserService.java
@@ -107,4 +107,12 @@ public interface UserService extends IService<User> {
      * @return the number of rows affected
      */
     int deleteUserByIds(Integer[] userIds);
+
+    /**
+     * Changes the user's password.
+     *
+     * @param user The user object containing the necessary password information.
+     * @return true if the password was successfully changed, false otherwise.
+     */
+    boolean changePassword(User user);
 }

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/UserServiceImpl.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/UserServiceImpl.java
@@ -52,6 +52,7 @@ import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.DigestUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -248,6 +249,12 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
     public int deleteUserByIds(Integer[] userIds) {
         userRoleMapper.deleteUserRole(userIds);
         return userMapper.deleteBatchIds(Arrays.asList(userIds));
+    }
+
+    @Override
+    public boolean changePassword(User user) {
+        user.setPassword(DigestUtils.md5DigestAsHex(user.getPassword().getBytes()));
+        return this.updateById(user);
     }
 
     private int insertUserRole(User user) {

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/UserControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/UserControllerTest.java
@@ -22,6 +22,7 @@ import org.apache.paimon.web.server.data.model.User;
 import org.apache.paimon.web.server.data.result.PageR;
 import org.apache.paimon.web.server.data.result.R;
 import org.apache.paimon.web.server.data.vo.UserVO;
+import org.apache.paimon.web.server.mapper.UserMapper;
 import org.apache.paimon.web.server.util.ObjectMapperUtils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -50,6 +52,8 @@ public class UserControllerTest extends ControllerTestBase {
 
     private static final int userId = 3;
     private static final String username = "test";
+
+    @Autowired private UserMapper userMapper;
 
     @Test
     @Order(1)
@@ -186,5 +190,23 @@ public class UserControllerTest extends ControllerTestBase {
 
         R<?> result = ObjectMapperUtils.fromJSON(delResponseString, R.class);
         assertEquals(200, result.getCode());
+    }
+
+    @Test
+    public void testChangePassword() throws Exception {
+        User user = new User();
+        user.setId(2);
+        user.setPassword("common");
+        mockMvc.perform(
+                        MockMvcRequestBuilders.post(userPath + "/change/password")
+                                .cookie(cookie)
+                                .content(ObjectMapperUtils.toJSON(user))
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .accept(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(MockMvcResultHandlers.print());
+
+        User newUser = userMapper.selectById(2);
+        assertEquals("9efab2399c7c560b34de477b9aa0a465", newUser.getPassword());
     }
 }


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/203

### Purpose

Add the user password change api.

### Tests

UserControllerTest#testChangePassword.

### API and Format

```
 /**
     * Changes a user's password.
     *
     * @param user the user object containing the new password
     * @return a response entity indicating success or failure
     */
    @SaCheckPermission("system:user:change:password")
    @PostMapping("/change/password")
    public R<Void> changePassword(@Validated @RequestBody User user) {
        if (userService.getUserById(user.getId()) == null) {
            return R.failed(USER_NOT_EXIST);
        }
        return userService.changePassword(user) ? R.succeed() : R.failed();
    }
```
