### PR TITLE
[Improvement] Optimize return value type for catalog service interface

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/CatalogController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/CatalogController.java
@@ -50,13 +50,16 @@ public class CatalogController {
     /**
      * Create a catalog.
      *
-     * @param catalogDTO The catalogDTO for the catalog.
-     * @return The created catalog.
+     * @param catalogDTO The catalogDTO for the catalog
+     * @return A response indicating the success or failure of the operation
      */
     @PostMapping("/create")
     public R<Void> createCatalog(@RequestBody CatalogDTO catalogDTO) {
         try {
-            return catalogService.createCatalog(catalogDTO);
+            if (catalogService.checkCatalogNameUnique(catalogDTO)) {
+                return R.failed(Status.CATALOG_NAME_IS_EXIST, catalogDTO.getName());
+            }
+            return catalogService.createCatalog(catalogDTO) ? R.succeed() : R.failed();
         } catch (Exception e) {
             log.error("Exception with creating catalog.", e);
             return R.failed(Status.CATALOG_CREATE_ERROR);
@@ -64,9 +67,9 @@ public class CatalogController {
     }
 
     /**
-     * Get all catalog information.
+     * Get all catalog information
      *
-     * @return The list of all catalogs.
+     * @return The list of all catalogs
      */
     @GetMapping("/list")
     public R<List<CatalogInfo>> getCatalog() {
@@ -77,8 +80,8 @@ public class CatalogController {
     /**
      * Removes a catalog with given catalog name or catalog id.
      *
-     * @param catalogDTO Given the catalog name or catalog id to remove catalog.
-     * @return A response indicating the success or failure of the operation.
+     * @param catalogDTO Given the catalog name or catalog id to remove catalog
+     * @return A response indicating the success or failure of the operation
      */
     @PostMapping("/remove")
     public R<Void> removeCatalog(@RequestBody CatalogDTO catalogDTO) {

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/CatalogController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/CatalogController.java
@@ -67,7 +67,7 @@ public class CatalogController {
     }
 
     /**
-     * Get all catalog information
+     * Get all catalog information.
      *
      * @return The list of all catalogs
      */

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/CatalogService.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/CatalogService.java
@@ -20,7 +20,6 @@ package org.apache.paimon.web.server.service;
 
 import org.apache.paimon.web.server.data.dto.CatalogDTO;
 import org.apache.paimon.web.server.data.model.CatalogInfo;
-import org.apache.paimon.web.server.data.result.R;
 
 import com.baomidou.mybatisplus.extension.service.IService;
 
@@ -36,10 +35,10 @@ public interface CatalogService extends IService<CatalogInfo> {
     boolean checkCatalogNameUnique(CatalogDTO catalog);
 
     /**
-     * Create a catalog.
+     * Creates a catalog.
      *
-     * @param catalogDTO catalog for the catalog.
-     * @return The created catalog.
+     * @param catalogDTO the data transfer object for catalog creation
+     * @return true if creation is successful, false otherwise
      */
-    R<Void> createCatalog(CatalogDTO catalogDTO);
+    boolean createCatalog(CatalogDTO catalogDTO);
 }

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/CatalogServiceImpl.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/CatalogServiceImpl.java
@@ -22,8 +22,6 @@ import org.apache.paimon.web.api.catalog.PaimonServiceFactory;
 import org.apache.paimon.web.server.data.dto.CatalogDTO;
 import org.apache.paimon.web.server.data.enums.CatalogMode;
 import org.apache.paimon.web.server.data.model.CatalogInfo;
-import org.apache.paimon.web.server.data.result.R;
-import org.apache.paimon.web.server.data.result.enums.Status;
 import org.apache.paimon.web.server.mapper.CatalogMapper;
 import org.apache.paimon.web.server.service.CatalogService;
 
@@ -45,11 +43,7 @@ public class CatalogServiceImpl extends ServiceImpl<CatalogMapper, CatalogInfo>
     }
 
     @Override
-    public R<Void> createCatalog(CatalogDTO catalogDTO) {
-        if (checkCatalogNameUnique(catalogDTO)) {
-            return R.failed(Status.CATALOG_NAME_IS_EXIST, catalogDTO.getName());
-        }
-
+    public boolean createCatalog(CatalogDTO catalogDTO) {
         if (catalogDTO.getType().equalsIgnoreCase(CatalogMode.FILESYSTEM.getMode())) {
             PaimonServiceFactory.createFileSystemCatalogService(
                     catalogDTO.getName(), catalogDTO.getWarehouse(), catalogDTO.getOptions());
@@ -78,6 +72,6 @@ public class CatalogServiceImpl extends ServiceImpl<CatalogMapper, CatalogInfo>
                         .isDelete(false)
                         .build();
 
-        return this.save(catalog) ? R.succeed() : R.failed();
+        return this.save(catalog);
     }
 }


### PR DESCRIPTION
Relates to: https://github.com/apache/paimon-webui/issues/205

### Purpose

This pull request aims to align the return types of our service layer interfaces with standard Spring framework practices by removing the use of a custom response wrapper (R). This change simplifies our service layer, ensuring it focuses solely on business logic and remains agnostic of HTTP response structures, as discussed in Issue #205.

