### PR TITLE
[Improvement] Encrypt user password before saving user

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/UserServiceImpl.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/UserServiceImpl.java
@@ -232,6 +232,7 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
     @Override
     @Transactional(rollbackFor = Exception.class)
     public int insertUser(User user) {
+        user.setPassword(DigestUtils.md5DigestAsHex(user.getPassword().getBytes()));
         this.save(user);
         return insertUserRole(user);
     }


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/210

### Purpose

The user password is not encrypted for creation of user at present. Therefore, the password should be encrypted before saving user.
