### PR TITLE
[Improvement]  Support permissions setting to UserInfoVO

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/data/vo/UserInfoVO.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/data/vo/UserInfoVO.java
@@ -49,4 +49,7 @@ public class UserInfoVO {
 
     /** current user's tenant. */
     private Tenant currentTenant;
+
+    /** current user's permissions list. */
+    private List<String> permissions;
 }

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/UserServiceImpl.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/UserServiceImpl.java
@@ -123,6 +123,7 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
         }*/
 
         StpUtil.login(user.getId(), loginDTO.isRememberMe());
+        userInfoVo.setPermissions(StpUtil.getPermissionList());
 
         return userInfoVo;
     }


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/214

### Purpose

When the frontend does button-level permission management, the back-end needs to return all permission strings of the current user. Currently, the login interface does not return the user's permission string, so it is necessary to return the user's permission string after logging in.

