### PR TITLE
[Improvement] Align naming of menu interface with system management conventions

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/SysMenuController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/SysMenuController.java
@@ -95,9 +95,9 @@ public class SysMenuController {
     }
 
     /** update menu. */
-    @SaCheckPermission("system:menu:edit")
+    @SaCheckPermission("system:menu:update")
     @PutMapping
-    public R<Void> edit(@Validated @RequestBody SysMenu menu) {
+    public R<Void> update(@Validated @RequestBody SysMenu menu) {
         if (!menuService.checkMenuNameUnique(menu)) {
             return R.failed(Status.MENU_NAME_IS_EXIST, menu.getMenuName());
         } else if (Constants.YES_FRAME == menu.getIsFrame()
@@ -108,9 +108,9 @@ public class SysMenuController {
     }
 
     /** delete menu. */
-    @SaCheckPermission("system:menu:remove")
+    @SaCheckPermission("system:menu:delete")
     @DeleteMapping("/{menuId}")
-    public R<Void> remove(@PathVariable("menuId") Integer menuId) {
+    public R<Void> delete(@PathVariable("menuId") Integer menuId) {
         if (menuService.hasChildByMenuId(menuId) || menuService.checkMenuExistRole(menuId)) {
             return R.failed(Status.MENU_IN_USED);
         }

--- a/scripts/sql/paimon-mysql.sql
+++ b/scripts/sql/paimon-mysql.sql
@@ -188,8 +188,8 @@ values (1, 'all', 0, 1, 'system', null, 1, 'M', 'system', 'admin', 'system root 
        (300, 'menu manager', 1, 1, 'menu', 'menu/index', 1, 'C', 'system:menu:list', 'menu', 'menu manager'),
        (3000, 'menu query', 300, 1, '', '', 1, 'F', 'system:menu:query', '#', ''),
        (3001, 'menu add', 300, 2, '', '', 1, 'F', 'system:menu:add', '#', ''),
-       (3002, 'menu edit', 300, 3, '', '', 1, 'F', 'system:menu:edit', '#', ''),
-       (3003, 'menu del', 300, 4, '', '', 1, 'F', 'system:menu:remove', '#', '');
+       (3002, 'menu update', 300, 3, '', '', 1, 'F', 'system:menu:update', '#', ''),
+       (3003, 'menu delete', 300, 4, '', '', 1, 'F', 'system:menu:delete', '#', '');
 
 insert into user_role (id, user_id, role_id)
 values (1, 1, 1), (2, 2, 2);


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/216

### Purpose

Currently, the interface method names of menu management are not unified with other interfaces of system management. In order to make the interface definition more standardized, the interface method names of menu management are unified here.
