### PR TITLE
[Feature] Bump Paimon version from 0.6-SNAPSHOT to 0.8.0

### DIFF
--- a/paimon-web-api/pom.xml
+++ b/paimon-web-api/pom.xml
@@ -34,7 +34,7 @@ under the License.
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <paimon.version>0.6-SNAPSHOT</paimon.version>
+        <paimon.version>0.8.0</paimon.version>
         <hadoop.version>2.8.5</hadoop.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@ under the License.
     <properties>
         <project.version>0.1-SNAPSHOT</project.version>
         <java.version>8</java.version>
-        <paimon.shade.version>0.6-SNAPSHOT</paimon.shade.version>
+        <paimon.shade.version>0.8.0</paimon.shade.version>
         <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
         <mysql-connector-java.version>8.0.28</mysql-connector-java.version>
         <maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>


### PR DESCRIPTION
### Purpose

Bump Paimon version from 0.6-SNAPSHOT to 0.8.0.

### Tests

Paimon v0.8.0 has been released, which should bump Paimon version from 0.6-SNAPSHOT.

### API and Format

None.

### Documentation

None.