### PR TITLE
[Improvement] Support changing status and assigning role of user 

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/UserController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/UserController.java
@@ -140,4 +140,28 @@ public class UserController {
         }
         return userService.changePassword(user) ? R.succeed() : R.failed();
     }
+
+    /**
+     * Changes the status of a user via a PUT request.
+     *
+     * @param user the user object containing the new status information
+     * @return a response object indicating success or failure
+     */
+    @SaCheckPermission("system:user:update")
+    @PutMapping("/changeStatus")
+    public R<Void> changeStatus(@RequestBody User user) {
+        return userService.updateUserStatus(user) ? R.succeed() : R.failed();
+    }
+
+    /**
+     * Allocates a role to a user.
+     *
+     * @param user the user to whom the role is to be allocated
+     * @return a response object indicating success or failure
+     */
+    @SaCheckPermission("system:user:update")
+    @PostMapping("/allocate")
+    public R<Void> allocateRole(@RequestBody User user) {
+        return userService.allocateRole(user) > 0 ? R.succeed() : R.failed();
+    }
 }

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/UserService.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/UserService.java
@@ -115,4 +115,20 @@ public interface UserService extends IService<User> {
      * @return true if the password was successfully changed, false otherwise.
      */
     boolean changePassword(User user);
+
+    /**
+     * Updates the status of the specified user.
+     *
+     * @param user the user whose status needs to be updated
+     * @return true if the update is successful, false otherwise
+     */
+    boolean updateUserStatus(User user);
+
+    /**
+     * Allocates roles to a user.
+     *
+     * @param user the user to whom the role should be allocated
+     * @return the number of rows affected
+     */
+    int allocateRole(User user);
 }

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/UserServiceImpl.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/UserServiceImpl.java
@@ -49,6 +49,7 @@ import cn.dev33.satoken.stp.StpUtil;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.google.common.base.Preconditions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -257,6 +258,20 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
     public boolean changePassword(User user) {
         user.setPassword(DigestUtils.md5DigestAsHex(user.getPassword().getBytes()));
         return this.updateById(user);
+    }
+
+    @Override
+    public boolean updateUserStatus(User user) {
+        Preconditions.checkArgument(user != null && user.getId() != null);
+        return this.lambdaUpdate()
+                .set(User::getEnabled, user.getEnabled())
+                .eq(User::getId, user.getId())
+                .update();
+    }
+
+    @Override
+    public int allocateRole(User user) {
+        return this.insertUserRole(user);
     }
 
     private int insertUserRole(User user) {


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/223

### Purpose

At present, the user interface does assign roles to users and modify user status interfaces. These two interfaces need to be added and front-end joint debugging.

### Tests

UserControllerTest#testAllocateRole.
UserControllerTest#testChangeUserStatus.

### API and Format

```
   * Changes the status of a user via a PUT request.
     *
     * @param user the user object containing the new status information
     * @return a response object indicating success or failure
     */
    @SaCheckPermission("system:user:update")
    @PutMapping("/changeStatus")
    public R<Void> changeStatus(@RequestBody User user) {
        return userService.updateUserStatus(user) ? R.succeed() : R.failed();
    }

    /**
     * Allocates a role to a user.
     *
     * @param user the user to whom the role is to be allocated
     * @return a response object indicating success or failure
     */
    @SaCheckPermission("system:user:update")
    @PostMapping("/allocate")
    public R<Void> allocateRole(@RequestBody User user) {
        return userService.allocateRole(user) > 0 ? R.succeed() : R.failed();
    }
```
