### PR TITLE
[Improvement] Refactor menu_name to use underscores for consistency

### DIFF
--- a/scripts/sql/paimon-mysql.sql
+++ b/scripts/sql/paimon-mysql.sql
@@ -173,23 +173,23 @@ values (1, 'admin', 'admin', 1),
        (2, 'common', 'common', 2);
 
 insert into sys_menu (id, menu_name, parent_id, sort, path, component, is_frame, type, perms, icon, remark)
-values (1, 'all', 0, 1, 'system', null, 1, 'M', 'system', 'admin', 'system root path'),
-       (100, 'user manager', 1, 1, 'user', 'user/index', 1, 'C', 'system:user:list', 'user', 'user manager'),
-       (1000, 'user query', 100, 1, '', '', 1, 'F', 'system:user:query', '#', ''),
-       (1001, 'user add', 100, 2, '', '', 1, 'F', 'system:user:add', '#', ''),
-       (1002, 'user update', 100, 3, '', '', 1, 'F', 'system:user:update', '#', ''),
-       (1003, 'user delete', 100, 4, '', '', 1, 'F', 'system:user:delete', '#', ''),
-       (1004, 'user reset', 100, 5, '', '', 1, 'F', 'system:user:change:password', '#', ''),
-       (200, 'role manager', 1, 1, 'role', 'role/index', 1, 'C', 'system:role:list', 'role', 'role manager'),
-       (2000, 'role query', 200, 1, '', '', 1, 'F', 'system:role:query', '#', ''),
-       (2001, 'role add', 200, 2, '', '', 1, 'F', 'system:role:add', '#', ''),
-       (2002, 'role update', 200, 3, '', '', 1, 'F', 'system:role:update', '#', ''),
-       (2003, 'role delete', 200, 4, '', '', 1, 'F', 'system:role:delete', '#', ''),
-       (300, 'menu manager', 1, 1, 'menu', 'menu/index', 1, 'C', 'system:menu:list', 'menu', 'menu manager'),
-       (3000, 'menu query', 300, 1, '', '', 1, 'F', 'system:menu:query', '#', ''),
-       (3001, 'menu add', 300, 2, '', '', 1, 'F', 'system:menu:add', '#', ''),
-       (3002, 'menu update', 300, 3, '', '', 1, 'F', 'system:menu:update', '#', ''),
-       (3003, 'menu delete', 300, 4, '', '', 1, 'F', 'system:menu:delete', '#', '');
+values (1, 'system', 0, 1, 'system', null, 1, 'M', 'system', 'admin', 'system root path'),
+       (100, 'user_manager', 1, 1, 'user', 'user/index', 1, 'C', 'system:user:list', 'user', 'user manager'),
+       (1000, 'user_query', 100, 1, '', '', 1, 'F', 'system:user:query', '#', ''),
+       (1001, 'user_add', 100, 2, '', '', 1, 'F', 'system:user:add', '#', ''),
+       (1002, 'user_update', 100, 3, '', '', 1, 'F', 'system:user:update', '#', ''),
+       (1003, 'user_delete', 100, 4, '', '', 1, 'F', 'system:user:delete', '#', ''),
+       (1004, 'user_reset', 100, 5, '', '', 1, 'F', 'system:user:change:password', '#', ''),
+       (200, 'role_manager', 1, 1, 'role', 'role/index', 1, 'C', 'system:role:list', 'role', 'role manager'),
+       (2000, 'role_query', 200, 1, '', '', 1, 'F', 'system:role:query', '#', ''),
+       (2001, 'role_add', 200, 2, '', '', 1, 'F', 'system:role:add', '#', ''),
+       (2002, 'role_update', 200, 3, '', '', 1, 'F', 'system:role:update', '#', ''),
+       (2003, 'role_delete', 200, 4, '', '', 1, 'F', 'system:role:delete', '#', ''),
+       (300, 'menu_manager', 1, 1, 'menu', 'menu/index', 1, 'C', 'system:menu:list', 'menu', 'menu manager'),
+       (3000, 'menu_query', 300, 1, '', '', 1, 'F', 'system:menu:query', '#', ''),
+       (3001, 'menu_add', 300, 2, '', '', 1, 'F', 'system:menu:add', '#', ''),
+       (3002, 'menu_update', 300, 3, '', '', 1, 'F', 'system:menu:update', '#', ''),
+       (3003, 'menu_delete', 300, 4, '', '', 1, 'F', 'system:menu:delete', '#', '');
 
 insert into user_role (id, user_id, role_id)
 values (1, 1, 1), (2, 2, 2);


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/225

### Purpose

Currently, the menu names in the menu table are separated by spaces. They need to be separated by underscores. The front end needs to use this as the key in the internationalization file.

