### PR TITLE
[Improvement] Add permission annotation for interface

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/CatalogController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/CatalogController.java
@@ -18,13 +18,13 @@
 
 package org.apache.paimon.web.server.controller;
 
-import cn.dev33.satoken.annotation.SaCheckPermission;
 import org.apache.paimon.web.server.data.dto.CatalogDTO;
 import org.apache.paimon.web.server.data.model.CatalogInfo;
 import org.apache.paimon.web.server.data.result.R;
 import org.apache.paimon.web.server.data.result.enums.Status;
 import org.apache.paimon.web.server.service.CatalogService;
 
+import cn.dev33.satoken.annotation.SaCheckPermission;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/CatalogController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/CatalogController.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.web.server.controller;
 
+import cn.dev33.satoken.annotation.SaCheckPermission;
 import org.apache.paimon.web.server.data.dto.CatalogDTO;
 import org.apache.paimon.web.server.data.model.CatalogInfo;
 import org.apache.paimon.web.server.data.result.R;
@@ -53,6 +54,7 @@ public class CatalogController {
      * @param catalogDTO The catalogDTO for the catalog
      * @return A response indicating the success or failure of the operation
      */
+    @SaCheckPermission("metadata:catalog:create")
     @PostMapping("/create")
     public R<Void> createCatalog(@RequestBody CatalogDTO catalogDTO) {
         try {
@@ -71,6 +73,7 @@ public class CatalogController {
      *
      * @return The list of all catalogs
      */
+    @SaCheckPermission("metadata:catalog:list")
     @GetMapping("/list")
     public R<List<CatalogInfo>> getCatalog() {
         List<CatalogInfo> catalogs = catalogService.list();
@@ -83,6 +86,7 @@ public class CatalogController {
      * @param catalogDTO Given the catalog name or catalog id to remove catalog
      * @return A response indicating the success or failure of the operation
      */
+    @SaCheckPermission("metadata:catalog:remove")
     @PostMapping("/remove")
     public R<Void> removeCatalog(@RequestBody CatalogDTO catalogDTO) {
         boolean remove;

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/CdcJobDefinitionController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/CdcJobDefinitionController.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.web.server.controller;
 
+import cn.dev33.satoken.annotation.SaCheckPermission;
 import org.apache.paimon.web.server.data.dto.CdcJobDefinitionDTO;
 import org.apache.paimon.web.server.data.model.CdcJobDefinition;
 import org.apache.paimon.web.server.data.result.PageR;
@@ -47,16 +48,19 @@ public class CdcJobDefinitionController {
         this.cdcJobDefinitionService = cdcJobDefinitionService;
     }
 
+    @SaCheckPermission("cdc:job:create")
     @PostMapping("create")
     public R<Void> createCdcJob(@RequestBody CdcJobDefinitionDTO cdcJobDefinitionDTO) {
         return cdcJobDefinitionService.create(cdcJobDefinitionDTO);
     }
 
+    @SaCheckPermission("cdc:job:update")
     @PutMapping("update")
     public R<Void> updateCdcJob(@RequestBody CdcJobDefinitionDTO cdcJobDefinitionDTO) {
         return cdcJobDefinitionService.update(cdcJobDefinitionDTO);
     }
 
+    @SaCheckPermission("cdc:job:list")
     @GetMapping("list")
     public PageR<CdcJobDefinition> listAllCdcJob(
             @RequestParam(required = false) boolean withConfig,
@@ -65,6 +69,7 @@ public class CdcJobDefinitionController {
         return cdcJobDefinitionService.listAll(withConfig, currentPage, pageSize);
     }
 
+    @SaCheckPermission("cdc:job:query")
     @GetMapping("/{id}")
     public R<CdcJobDefinition> getById(@PathVariable Integer id) {
         CdcJobDefinition cdcJobDefinition = cdcJobDefinitionService.getById(id);
@@ -74,6 +79,7 @@ public class CdcJobDefinitionController {
         return R.succeed(cdcJobDefinition);
     }
 
+    @SaCheckPermission("cdc:job:delete")
     @DeleteMapping("{id}")
     public R<Void> deleteById(@PathVariable Integer id) {
         cdcJobDefinitionService.removeById(id);

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/CdcJobDefinitionController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/CdcJobDefinitionController.java
@@ -18,13 +18,13 @@
 
 package org.apache.paimon.web.server.controller;
 
-import cn.dev33.satoken.annotation.SaCheckPermission;
 import org.apache.paimon.web.server.data.dto.CdcJobDefinitionDTO;
 import org.apache.paimon.web.server.data.model.CdcJobDefinition;
 import org.apache.paimon.web.server.data.result.PageR;
 import org.apache.paimon.web.server.data.result.R;
 import org.apache.paimon.web.server.service.CdcJobDefinitionService;
 
+import cn.dev33.satoken.annotation.SaCheckPermission;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/DatabaseController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/DatabaseController.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.web.server.controller;
 
+import cn.dev33.satoken.annotation.SaCheckPermission;
 import org.apache.paimon.web.server.data.dto.DatabaseDTO;
 import org.apache.paimon.web.server.data.result.R;
 import org.apache.paimon.web.server.data.result.enums.Status;
@@ -52,6 +53,7 @@ public class DatabaseController {
      * @param databaseDTO The details of the database to create
      * @return a {@code R<Void>} response indicating success or failure
      */
+    @SaCheckPermission("metadata:database:create")
     @PostMapping("/create")
     public R<Void> createDatabase(@RequestBody DatabaseDTO databaseDTO) {
         if (databaseService.databaseExists(databaseDTO)) {
@@ -67,6 +69,7 @@ public class DatabaseController {
      *
      * @return The list of databases of given catalog id
      */
+    @SaCheckPermission("metadata:database:list")
     @GetMapping("/list")
     public R<List<DatabaseVO>> listDatabases(
             @RequestParam(value = "catalogId", required = false) Integer catalogId) {
@@ -79,6 +82,7 @@ public class DatabaseController {
      * @param databaseDTO The database to be dropped
      * @return a {@code R<Void>} response indicating success or failure
      */
+    @SaCheckPermission("metadata:database:drop")
     @PostMapping("/drop")
     public R<Void> dropDatabase(@RequestBody DatabaseDTO databaseDTO) {
         return databaseService.dropDatabase(databaseDTO)

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/DatabaseController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/DatabaseController.java
@@ -18,13 +18,13 @@
 
 package org.apache.paimon.web.server.controller;
 
-import cn.dev33.satoken.annotation.SaCheckPermission;
 import org.apache.paimon.web.server.data.dto.DatabaseDTO;
 import org.apache.paimon.web.server.data.result.R;
 import org.apache.paimon.web.server.data.result.enums.Status;
 import org.apache.paimon.web.server.data.vo.DatabaseVO;
 import org.apache.paimon.web.server.service.DatabaseService;
 
+import cn.dev33.satoken.annotation.SaCheckPermission;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/MetadataController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/MetadataController.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.web.server.controller;
 
-import cn.dev33.satoken.annotation.SaCheckPermission;
 import org.apache.paimon.web.server.data.dto.MetadataDTO;
 import org.apache.paimon.web.server.data.result.R;
 import org.apache.paimon.web.server.data.vo.DataFileVO;
@@ -28,6 +27,7 @@ import org.apache.paimon.web.server.data.vo.SchemaVO;
 import org.apache.paimon.web.server.data.vo.SnapshotVO;
 import org.apache.paimon.web.server.service.MetadataService;
 
+import cn.dev33.satoken.annotation.SaCheckPermission;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/MetadataController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/MetadataController.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.web.server.controller;
 
+import cn.dev33.satoken.annotation.SaCheckPermission;
 import org.apache.paimon.web.server.data.dto.MetadataDTO;
 import org.apache.paimon.web.server.data.result.R;
 import org.apache.paimon.web.server.data.vo.DataFileVO;
@@ -47,26 +48,31 @@ public class MetadataController {
         this.metadataService = metadataService;
     }
 
+    @SaCheckPermission("metadata:schema:list")
     @PostMapping("/schema")
     public R<List<SchemaVO>> getSchemaInfo(@RequestBody MetadataDTO dto) {
         return R.succeed(metadataService.getSchema(dto));
     }
 
+    @SaCheckPermission("metadata:snapshot:list")
     @PostMapping("/snapshot")
     public R<List<SnapshotVO>> getSnapshotInfo(@RequestBody MetadataDTO dto) {
         return R.succeed(metadataService.getSnapshot(dto));
     }
 
+    @SaCheckPermission("metadata:manifest:list")
     @PostMapping("/manifest")
     public R<List<ManifestsVO>> getManifestInfo(@RequestBody MetadataDTO dto) {
         return R.succeed(metadataService.getManifest(dto));
     }
 
+    @SaCheckPermission("metadata:datafile:list")
     @PostMapping("/dataFile")
     public R<List<DataFileVO>> getDataFileInfo(@RequestBody MetadataDTO dto) {
         return R.succeed(metadataService.getDataFile(dto));
     }
 
+    @SaCheckPermission("metadata:options:list")
     @PostMapping("/options")
     public R<List<OptionVO>> getOptionInfo(@RequestBody MetadataDTO dto) {
         return R.succeed(metadataService.getOption(dto));

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/TableController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/TableController.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.web.server.controller;
 
+import cn.dev33.satoken.annotation.SaCheckPermission;
 import org.apache.paimon.web.server.data.dto.AlterTableDTO;
 import org.apache.paimon.web.server.data.dto.TableDTO;
 import org.apache.paimon.web.server.data.result.R;
@@ -59,6 +60,7 @@ public class TableController {
      * @param tableDTO The TableDTO object containing information about the table
      * @return a {@code R<Void>} response indicating success or failure
      */
+    @SaCheckPermission("metadata:table:create")
     @PostMapping("/create")
     public R<Void> createTable(@RequestBody TableDTO tableDTO) {
         if (tableService.tableExists(tableDTO)) {
@@ -75,6 +77,7 @@ public class TableController {
      * @param tableDTO The TableDTO object containing information about the table
      * @return a {@code R<Void>} response indicating success or failure
      */
+    @SaCheckPermission("metadata:column:add")
     @PostMapping("/column/add")
     public R<Void> addColumn(@RequestBody TableDTO tableDTO) {
         return tableService.addColumn(tableDTO)
@@ -90,6 +93,7 @@ public class TableController {
      * @param tableName The name of the table
      * @return Response object containing {@link TableVO} representing the table
      */
+    @SaCheckPermission("metadata:column:list")
     @GetMapping("/column/list")
     public R<TableVO> listColumns(
             @RequestParam String catalogName,
@@ -107,6 +111,7 @@ public class TableController {
      * @param columnName The name of the column to be dropped
      * @return a {@code R<Void>} response indicating success or failure
      */
+    @SaCheckPermission("metadata:column:drop")
     @DeleteMapping("/column/drop/{catalogName}/{databaseName}/{tableName}/{columnName}")
     public R<Void> dropColumn(
             @PathVariable String catalogName,
@@ -124,6 +129,7 @@ public class TableController {
      * @param alterTableDTO the DTO containing alteration details
      * @return a {@code R<Void>} response indicating success or failure
      */
+    @SaCheckPermission("metadata:table:update")
     @PostMapping("/alter")
     public R<Void> alterTable(@RequestBody AlterTableDTO alterTableDTO) {
         return tableService.alterTable(alterTableDTO)
@@ -137,6 +143,7 @@ public class TableController {
      * @param tableDTO The TableDTO object containing information about the table
      * @return a {@code R<Void>} response indicating success or failure
      */
+    @SaCheckPermission("metadata:option:add")
     @PostMapping("/option/add")
     public R<Void> addOption(@RequestBody TableDTO tableDTO) {
         return tableService.addOption(tableDTO)
@@ -153,6 +160,7 @@ public class TableController {
      * @param key The key of the option to be removed
      * @return a {@code R<Void>} response indicating success or failure
      */
+    @SaCheckPermission("metadata:option:remove")
     @PostMapping("/option/remove")
     public R<Void> removeOption(
             @RequestParam String catalogName,
@@ -172,6 +180,7 @@ public class TableController {
      * @param tableName The name of the table to be dropped
      * @return a {@code R<Void>} response indicating success or failure
      */
+    @SaCheckPermission("metadata:table:drop")
     @DeleteMapping("/drop/{catalogName}/{databaseName}/{tableName}")
     public R<Void> dropTable(
             @PathVariable String catalogName,
@@ -191,6 +200,7 @@ public class TableController {
      * @param toTableName The new name for the table
      * @return a {@code R<Void>} response indicating success or failure
      */
+    @SaCheckPermission("metadata:table:update")
     @PostMapping("/rename")
     public R<Void> renameTable(
             @RequestParam String catalogName,
@@ -207,6 +217,7 @@ public class TableController {
      *
      * @return Response object containing a list of {@link TableVO} representing the tables
      */
+    @SaCheckPermission("metadata:table:list")
     @PostMapping("/list")
     public R<Object> listTables(@RequestBody TableDTO tableDTO) {
         List<TableVO> tables = tableService.listTables(tableDTO);

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/TableController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/TableController.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.web.server.controller;
 
-import cn.dev33.satoken.annotation.SaCheckPermission;
 import org.apache.paimon.web.server.data.dto.AlterTableDTO;
 import org.apache.paimon.web.server.data.dto.TableDTO;
 import org.apache.paimon.web.server.data.result.R;
@@ -26,6 +25,7 @@ import org.apache.paimon.web.server.data.result.enums.Status;
 import org.apache.paimon.web.server.data.vo.TableVO;
 import org.apache.paimon.web.server.service.TableService;
 
+import cn.dev33.satoken.annotation.SaCheckPermission;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;


### PR DESCRIPTION

### Purpose

Some interfaces were previously developed without permission annotations. This PR completes the permission annotations of the interface and is used to control user permissions.
