### PR TITLE
[Improvement] Support assigning sort field with value when creating a role

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/SysRoleServiceImpl.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/SysRoleServiceImpl.java
@@ -169,6 +169,8 @@ public class SysRoleServiceImpl extends ServiceImpl<SysRoleMapper, SysRole>
     @Override
     @Transactional(rollbackFor = Exception.class)
     public int insertRole(SysRole role) {
+        List<SysRole> list = this.list();
+        role.setSort(list.size() + 1);
         this.save(role);
         return insertRoleMenu(role);
     }


### PR DESCRIPTION

### Purpose

There is no default value assigned to the sort field of the role. You need to assign a value to the sort field when the backend creates the role.
