### PR TITLE
[Improvement] Add admin flag for role entity

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/data/model/SysRole.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/data/model/SysRole.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.web.server.data.model;
 
+import org.apache.paimon.web.server.constant.Constants;
+
 import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableLogic;
 import lombok.Data;
@@ -58,6 +60,14 @@ public class SysRole extends BaseModel {
     /** Role menu permissions. */
     @TableField(exist = false)
     private Set<String> permissions;
+
+    public boolean isAdmin() {
+        return isAdmin(this.getId());
+    }
+
+    public static boolean isAdmin(Integer roleId) {
+        return roleId != null && Constants.ADMIN_ID == roleId;
+    }
 
     private static final long serialVersionUID = 1L;
 }


### PR DESCRIPTION

### Purpose

Add the admin identifier to the role entity to determine whether the returned role is an administrator.