### PR TITLE
[Improvement] Fill in the execution mode for the statement

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/JobServiceImpl.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/JobServiceImpl.java
@@ -100,6 +100,16 @@ public class JobServiceImpl extends ServiceImpl<JobMapper, JobInfo> implements J
                     addPipelineNameStatement(pipelineName, jobSubmitDTO.getStatements()));
         }
 
+        if (jobSubmitDTO.isStreaming()) {
+            jobSubmitDTO.setStatements(
+                    addExecutionModeStatement(
+                            STREAMING_MODE.toLowerCase(), jobSubmitDTO.getStatements()));
+        } else {
+            jobSubmitDTO.setStatements(
+                    addExecutionModeStatement(
+                            BATCH_MODE.toLowerCase(), jobSubmitDTO.getStatements()));
+        }
+
         Executor executor =
                 this.getExecutor(jobSubmitDTO.getClusterId(), jobSubmitDTO.getTaskType());
         if (executor == null) {
@@ -435,6 +445,10 @@ public class JobServiceImpl extends ServiceImpl<JobMapper, JobInfo> implements J
 
     private String addPipelineNameStatement(String pipelineName, String statements) {
         return "SET 'pipeline.name' = '" + pipelineName + "';\n" + statements;
+    }
+
+    private String addExecutionModeStatement(String executionMode, String statements) {
+        return "SET 'execution.runtime-mode' = '" + executionMode + "';\n" + statements;
     }
 
     private boolean shouldCreateSession(String clusterId) {

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/JobControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/JobControllerTest.java
@@ -81,8 +81,7 @@ public class JobControllerTest extends FlinkSQLGatewayTestBase {
 
     @Autowired private ClusterService clusterService;
 
-    @Autowired
-    private HistoryService historyService;
+    @Autowired private HistoryService historyService;
 
     @BeforeEach
     public void before() throws Exception {

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/JobControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/JobControllerTest.java
@@ -24,12 +24,14 @@ import org.apache.paimon.web.server.data.dto.LoginDTO;
 import org.apache.paimon.web.server.data.dto.ResultFetchDTO;
 import org.apache.paimon.web.server.data.dto.StopJobDTO;
 import org.apache.paimon.web.server.data.model.ClusterInfo;
+import org.apache.paimon.web.server.data.model.History;
 import org.apache.paimon.web.server.data.result.R;
 import org.apache.paimon.web.server.data.vo.JobStatisticsVO;
 import org.apache.paimon.web.server.data.vo.JobStatusVO;
 import org.apache.paimon.web.server.data.vo.JobVO;
 import org.apache.paimon.web.server.data.vo.ResultDataVO;
 import org.apache.paimon.web.server.service.ClusterService;
+import org.apache.paimon.web.server.service.HistoryService;
 import org.apache.paimon.web.server.util.ObjectMapperUtils;
 import org.apache.paimon.web.server.util.StringUtils;
 
@@ -78,6 +80,9 @@ public class JobControllerTest extends FlinkSQLGatewayTestBase {
     public static MockCookie cookie;
 
     @Autowired private ClusterService clusterService;
+
+    @Autowired
+    private HistoryService historyService;
 
     @BeforeEach
     public void before() throws Exception {
@@ -146,6 +151,7 @@ public class JobControllerTest extends FlinkSQLGatewayTestBase {
         JobSubmitDTO jobSubmitDTO = new JobSubmitDTO();
         jobSubmitDTO.setJobName("flink-job-test");
         jobSubmitDTO.setTaskType("Flink");
+        jobSubmitDTO.setStreaming(true);
         jobSubmitDTO.setClusterId(String.valueOf(one.getId()));
         jobSubmitDTO.setStatements(StatementsConstant.statement);
 
@@ -168,6 +174,7 @@ public class JobControllerTest extends FlinkSQLGatewayTestBase {
         JobSubmitDTO jobSubmitDTO = new JobSubmitDTO();
         jobSubmitDTO.setJobName("flink-job-test-fetch-result");
         jobSubmitDTO.setTaskType("Flink");
+        jobSubmitDTO.setStreaming(true);
         jobSubmitDTO.setClusterId(String.valueOf(one.getId()));
         jobSubmitDTO.setStatements(StatementsConstant.selectStatement);
 
@@ -212,6 +219,7 @@ public class JobControllerTest extends FlinkSQLGatewayTestBase {
         JobSubmitDTO jobSubmitDTO = new JobSubmitDTO();
         jobSubmitDTO.setJobName("flink-job-test-list-jobs");
         jobSubmitDTO.setTaskType("Flink");
+        jobSubmitDTO.setStreaming(true);
         jobSubmitDTO.setClusterId(String.valueOf(one.getId()));
         jobSubmitDTO.setStatements(StatementsConstant.selectStatement);
 
@@ -253,6 +261,7 @@ public class JobControllerTest extends FlinkSQLGatewayTestBase {
         JobSubmitDTO jobSubmitDTO = new JobSubmitDTO();
         jobSubmitDTO.setJobName("flink-job-test-get-job-status");
         jobSubmitDTO.setTaskType("Flink");
+        jobSubmitDTO.setStreaming(true);
         jobSubmitDTO.setClusterId(String.valueOf(one.getId()));
         jobSubmitDTO.setStatements(StatementsConstant.selectStatement);
 
@@ -278,6 +287,7 @@ public class JobControllerTest extends FlinkSQLGatewayTestBase {
         JobSubmitDTO jobSubmitDTO = new JobSubmitDTO();
         jobSubmitDTO.setJobName("flink-job-test-stop-job");
         jobSubmitDTO.setTaskType("Flink");
+        jobSubmitDTO.setStreaming(true);
         jobSubmitDTO.setClusterId(String.valueOf(one.getId()));
         jobSubmitDTO.setStatements(StatementsConstant.selectStatement);
         String responseString = submit(jobSubmitDTO);
@@ -331,6 +341,7 @@ public class JobControllerTest extends FlinkSQLGatewayTestBase {
         JobSubmitDTO jobSubmitDTO = new JobSubmitDTO();
         jobSubmitDTO.setJobName("flink-job-test-get-job-statistics");
         jobSubmitDTO.setTaskType("Flink");
+        jobSubmitDTO.setStreaming(true);
         jobSubmitDTO.setClusterId(String.valueOf(one.getId()));
         jobSubmitDTO.setStatements(StatementsConstant.selectStatement);
         String responseString = submit(jobSubmitDTO);
@@ -360,6 +371,13 @@ public class JobControllerTest extends FlinkSQLGatewayTestBase {
         assertEquals(1, getJobStatisticsRes.getData().getCanceledNum());
         assertEquals(0, getJobStatisticsRes.getData().getFinishedNum());
         assertEquals(0, getJobStatisticsRes.getData().getFailedNum());
+    }
+
+    @Test
+    @Order(7)
+    public void testExecutionMode() {
+        History history = historyService.list().get(0);
+        assertTrue(history.getStatements().contains("SET 'execution.runtime-mode' = 'streaming';"));
     }
 
     private String submit(JobSubmitDTO jobSubmitDTO) throws Exception {


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/267

### Purpose

Fill in the execution mode for statement. If the front-end selects the execution mode as Streaming, the back-end fills in SET 'execution.runtime-mode' = 'streaming' for statement; If the front-end selects the execution mode as Batch, the back-end fills in SET 'execution.runtime-mode' = 'batch' for statement;
