### PR TITLE
[Bugfix] Fix creating table without partition key

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/TableServiceImpl.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/TableServiceImpl.java
@@ -38,6 +38,8 @@ import org.apache.paimon.web.server.util.PaimonServiceUtils;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -96,15 +98,23 @@ public class TableServiceImpl implements TableService {
                 }
             }
 
-            TableMetadata tableMetadata =
+            TableMetadata.Builder builder =
                     TableMetadata.builder()
                             .columns(buildColumns(tableDTO))
-                            .partitionKeys(partitionKeys)
-                            .primaryKeys(buildPrimaryKeys(tableDTO))
-                            .options(tableOptions)
-                            .comment(tableDTO.getDescription())
-                            .build();
-            service.createTable(tableDTO.getDatabaseName(), tableDTO.getName(), tableMetadata);
+                            .primaryKeys(buildPrimaryKeys(tableDTO));
+
+            if (CollectionUtils.isNotEmpty(partitionKeys)) {
+                builder.partitionKeys(partitionKeys);
+            }
+
+            if (MapUtils.isNotEmpty(tableOptions)) {
+                builder.options(tableOptions);
+            }
+
+            if (StringUtils.isNotEmpty(tableDTO.getDescription())) {
+                builder.comment(tableDTO.getDescription());
+            }
+            service.createTable(tableDTO.getDatabaseName(), tableDTO.getName(), builder.build());
             return true;
         } catch (Exception e) {
             log.error("Exception with creating table.", e);

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/TableControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/TableControllerTest.java
@@ -50,6 +50,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /** Test for {@link TableController}. */
 public class TableControllerTest extends ControllerTestBase {
@@ -200,6 +201,43 @@ public class TableControllerTest extends ControllerTestBase {
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    public void testCreateTable() throws Exception {
+        List<TableColumn> tableColumns = new ArrayList<>();
+        TableColumn id =
+                TableColumn.builder()
+                        .field("f1")
+                        .dataType(PaimonDataType.builder().type("INT").build())
+                        .build();
+        tableColumns.add(id);
+
+        TableDTO table =
+                TableDTO.builder()
+                        .catalogName(catalogName)
+                        .databaseName(databaseName)
+                        .name("test_table")
+                        .tableColumns(tableColumns)
+                        .build();
+
+        String responseString =
+                mockMvc.perform(
+                                MockMvcRequestBuilders.post(tablePath + "/create")
+                                        .cookie(cookie)
+                                        .content(ObjectMapperUtils.toJSON(table))
+                                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                        .accept(MediaType.APPLICATION_JSON_VALUE))
+                        .andExpect(MockMvcResultMatchers.status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        R<Void> r = ObjectMapperUtils.fromJSON(responseString, new TypeReference<R<Void>>() {});
+        assertEquals(200, r.getCode());
+        List<TableVO> tables = getTables();
+        assertFalse(tables.isEmpty());
+        assertEquals("test_table", tables.get(1).getName());
     }
 
     @Test


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/279

### Purpose

Fixed the bug that table cannot be created without partition key.

### Tests

TableControllerTest#testCreateTable.
