### PR TITLE
[Improvement] Align field names displayed on the Snapshot page with the backend interface

### DIFF
--- a/paimon-web-ui/src/views/metadata/components/schema/index.tsx
+++ b/paimon-web-ui/src/views/metadata/components/schema/index.tsx
@@ -103,7 +103,7 @@ export default defineComponent({
             row-key={(rowData: Schema) => rowData.schemaId}
             columns={this.columns}
             data={this.schemaData || []}
-            max-height="calc(100vh - 260px)"
+            max-height="calc(100vh - 280px)"
           />
         </n-spin>
       </n-card>

--- a/paimon-web-ui/src/views/metadata/components/snapshot/index.tsx
+++ b/paimon-web-ui/src/views/metadata/components/snapshot/index.tsx
@@ -64,32 +64,32 @@ export default defineComponent({
         },
       },
       {
-        title: 'Base ManifestList',
+        title: 'Base Manifest List',
         key: 'baseManifestList',
         width: 430,
       },
       {
-        title: 'Delta ManifestList',
+        title: 'Delta Manifest List',
         key: 'deltaManifestList',
         width: 430,
       },
       {
-        title: 'Changelog ManifestList',
+        title: 'Changelog Manifest List',
         key: 'changelogManifestList',
         width: 430,
       },
       {
-        title: 'Total RecordCount',
+        title: 'Total Record Count',
         key: 'totalRecordCount',
         width: 170,
       },
       {
-        title: 'Delta RecordCount',
+        title: 'Delta Record Count',
         key: 'deltaRecordCount',
         width: 170,
       },
       {
-        title: 'Changelog RecordCount',
+        title: 'Changelog Record Count',
         key: 'changelogRecordCount',
         width: 210,
       },

--- a/paimon-web-ui/src/views/metadata/components/snapshot/index.tsx
+++ b/paimon-web-ui/src/views/metadata/components/snapshot/index.tsx
@@ -32,26 +32,71 @@ export default defineComponent({
       {
         title: 'Snapshot ID',
         key: 'snapshotId',
+        width: 120,
       },
       {
         title: 'Schema ID',
         key: 'schemaId',
+        width: 120,
+      },
+      {
+        title: 'Commit User',
+        key: 'commitUser',
+        width: 330,
       },
       {
         title: 'Commit Identifier',
         key: 'commitIdentifier',
+        width: 170,
       },
 
       {
         title: 'Commit Kind',
         key: 'commitKind',
+        width: 140,
       },
       {
         title: 'Commit Time',
         key: 'commitTime',
+        width: 190,
         render: (row) => {
           return dayjs(row.commitTime).format('YYYY-MM-DD HH:mm:ss')
         },
+      },
+      {
+        title: 'Base ManifestList',
+        key: 'baseManifestList',
+        width: 430,
+      },
+      {
+        title: 'Delta ManifestList',
+        key: 'deltaManifestList',
+        width: 430,
+      },
+      {
+        title: 'Changelog ManifestList',
+        key: 'changelogManifestList',
+        width: 430,
+      },
+      {
+        title: 'Total RecordCount',
+        key: 'totalRecordCount',
+        width: 170,
+      },
+      {
+        title: 'Delta RecordCount',
+        key: 'deltaRecordCount',
+        width: 170,
+      },
+      {
+        title: 'Changelog RecordCount',
+        key: 'changelogRecordCount',
+        width: 210,
+      },
+      {
+        title: 'Watermark',
+        key: 'watermark',
+        width: 220,
       },
     ]
 
@@ -78,6 +123,8 @@ export default defineComponent({
           <n-data-table
             columns={this.columns}
             data={this.snapshots || []}
+            max-height="calc(100vh - 280px)"
+            scroll-x="3200px"
           />
         </n-spin>
       </n-card>

--- a/paimon-web-ui/src/views/metadata/index.module.scss
+++ b/paimon-web-ui/src/views/metadata/index.module.scss
@@ -23,6 +23,8 @@ under the License. */
   .content {
     display: flex;
     flex-direction: column;
+    flex-grow: 1;
+    overflow-x: auto;
     
     width: calc(100% - 60px);
 


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/281

### Purpose

Align the fields displayed on the Snapshot page with the backend.

![image](https://github.com/apache/paimon-webui/assets/34889415/c9404dd4-3fe5-443e-965b-1341cf0e0308)

![image](https://github.com/apache/paimon-webui/assets/34889415/1b1be5ab-c9f5-475b-9899-7749277b9b12)

![image](https://github.com/apache/paimon-webui/assets/34889415/a30bec70-7fe3-4a8f-b01a-47791c1b1b3d)

