### PR TITLE
[Improvement] Support selecting a session cluster when submitting CDC jobs

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/data/dto/CdcJobSubmitDTO.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/data/dto/CdcJobSubmitDTO.java
@@ -24,5 +24,5 @@ import lombok.Data;
 @Data
 public class CdcJobSubmitDTO {
 
-    private String flinkSessionUrl;
+    private String clusterId;
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Support selecting a session cluster when submitting CDC jobs . Link issue #290 

### Tests

No change

### API and Format

```java
    @PostMapping("{id}/submit")
    public R<Void> submit(@PathVariable Integer id, @RequestBody CdcJobSubmitDTO cdcJobSubmitDTO) {
        return cdcJobDefinitionService.submit(id, cdcJobSubmitDTO);
    }
```

