### PR TITLE
[Improvement] Align field names displayed on the Manifest page with the backend interface

### DIFF
--- a/paimon-web-ui/src/views/metadata/components/manifest/index.tsx
+++ b/paimon-web-ui/src/views/metadata/components/manifest/index.tsx
@@ -41,6 +41,14 @@ export default defineComponent({
         title: 'Number of Add Files',
         key: 'numAddedFiles',
       },
+      {
+        title: 'Number of Delete Files',
+        key: 'numDeletedFiles',
+      },
+      {
+        title: 'schemaId',
+        key: 'schemaId',
+      },
     ]
 
     const onFetchData = async () => {

--- a/paimon-web-ui/src/views/metadata/components/manifest/index.tsx
+++ b/paimon-web-ui/src/views/metadata/components/manifest/index.tsx
@@ -75,6 +75,7 @@ export default defineComponent({
           <n-data-table
             columns={this.columns}
             data={this.manifest || []}
+            max-height="calc(100vh - 280px)"
           />
         </n-spin>
       </n-card>


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/283

### Purpose

Align the fields displayed on the Menifest page with the backend.

![image](https://github.com/apache/paimon-webui/assets/34889415/2e8befb1-9fd4-4c99-acc8-ed870f0df628)

![image](https://github.com/apache/paimon-webui/assets/34889415/5585a660-6596-425e-8730-2d2d6e3219dc)
