### PR TITLE
[Improvement] Align field names displayed on the DataFile page with the backend interface

### DIFF
--- a/paimon-web-ui/src/views/metadata/components/datafile/index.tsx
+++ b/paimon-web-ui/src/views/metadata/components/datafile/index.tsx
@@ -17,6 +17,7 @@ under the License. */
 
 import type { DataTableColumns } from 'naive-ui'
 
+import dayjs from 'dayjs'
 import { type Datafile, getDataFile } from '@/api/models/catalog'
 import { useCatalogStore } from '@/store/catalog'
 
@@ -27,22 +28,105 @@ export default defineComponent({
 
     const catalogStore = useCatalogStore()
 
+    function parseKeyValueStringToJsonString(dataStr: string) {
+      const result: { [key: string]: string } = {}
+      const cleanStr = dataStr.replace(/^\{|\}$/g, '')
+      const keyValuePairs = cleanStr.split(',')
+      keyValuePairs.forEach((pair) => {
+        const [key, value] = pair.split('=').map(item => item.trim())
+        result[key] = value
+      })
+      return JSON.stringify(result, null, 2)
+    }
+
     const columns: DataTableColumns<Datafile> = [
       {
-        title: 'Partition',
-        key: 'partition',
-      },
-      {
-        title: 'Bucket',
-        key: 'bucket',
+        title: '#',
+        type: 'expand',
+        renderExpand: (row) => {
+          const nullValueJsonString = parseKeyValueStringToJsonString(row.nullValueCounts || '')
+          const minValueStatsJsonString = parseKeyValueStringToJsonString(row.minValueStats || '')
+          const maxValueStatsJsonString = parseKeyValueStringToJsonString(row.maxValueStats || '')
+
+          return (
+            <div>
+              <div>Null Value Counts: </div>
+              <pre>{nullValueJsonString}</pre>
+              <div>Min Value Stats: </div>
+              <pre>{minValueStatsJsonString}</pre>
+              <div>Max Value Stats: </div>
+              <pre>{maxValueStatsJsonString}</pre>
+            </div>
+          )
+        },
       },
       {
         title: 'File Path',
         key: 'filePath',
+        width: 420,
+      },
+      {
+        title: 'Partition',
+        key: 'partition',
+        width: 120,
+      },
+      {
+        title: 'Bucket',
+        key: 'bucket',
+        width: 120,
       },
       {
         title: 'File Format',
         key: 'fileFormat',
+        width: 120,
+      },
+      {
+        title: 'SchemaId',
+        key: 'schemaId',
+        width: 120,
+      },
+      {
+        title: 'Level',
+        key: 'level',
+        width: 80,
+      },
+      {
+        title: 'Record Count',
+        key: 'recordCount',
+        width: 140,
+      },
+      {
+        title: 'File Size In Bytes',
+        key: 'fileSizeInBytes',
+        width: 160,
+      },
+      {
+        title: 'Min Key',
+        key: 'minKey',
+        width: 160,
+      },
+      {
+        title: 'Max Key',
+        key: 'maxKey',
+        width: 160,
+      },
+      {
+        title: 'Min Sequence Number',
+        key: 'minSequenceNumber',
+        width: 180,
+      },
+      {
+        title: 'Max Sequence Number',
+        key: 'maxSequenceNumber',
+        width: 180,
+      },
+      {
+        title: 'Creation Time',
+        key: 'creationTime',
+        width: 180,
+        render: (row) => {
+          return dayjs(row.creationTime).format('YYYY-MM-DD HH:mm:ss')
+        },
       },
     ]
 
@@ -67,8 +151,11 @@ export default defineComponent({
       <n-card>
         <n-spin show={this.loading}>
           <n-data-table
+            row-key={(rowData: Datafile) => rowData.filePath}
             columns={this.columns}
             data={this.datafiles || []}
+            max-height="calc(100vh - 280px)"
+            scroll-x="2200px"
           />
         </n-spin>
       </n-card>

--- a/paimon-web-ui/src/views/metadata/components/datafile/index.tsx
+++ b/paimon-web-ui/src/views/metadata/components/datafile/index.tsx
@@ -130,6 +130,14 @@ export default defineComponent({
       },
     ]
 
+    const totalWidth = computed(() => {
+      const extraPixels = 60
+      return `${columns.reduce((sum, col) => {
+        const width = typeof col.width === 'number' ? col.width : 0
+        return sum + width
+      }, 0) + extraPixels}px`
+    })
+
     const onFetchData = async () => {
       useDataFile({
         params: catalogStore.currentTable,
@@ -144,6 +152,7 @@ export default defineComponent({
       columns,
       datafiles,
       loading,
+      totalWidth,
     }
   },
   render() {
@@ -155,7 +164,7 @@ export default defineComponent({
             columns={this.columns}
             data={this.datafiles || []}
             max-height="calc(100vh - 280px)"
-            scroll-x="2200px"
+            scroll-x={this.totalWidth}
           />
         </n-spin>
       </n-card>


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/284

### Purpose

 Align field names displayed on the DataFile page with the backend interface.

![image](https://github.com/apache/paimon-webui/assets/34889415/79a427fb-9e77-4a84-95ae-29f9d32e588d)

![image](https://github.com/apache/paimon-webui/assets/34889415/62a49391-ee68-48e4-bb37-0138eec770b0)



