### PR TITLE
[Improvement] Optimize the display position of option page fields

### DIFF
--- a/paimon-web-ui/src/views/metadata/components/options/index.tsx
+++ b/paimon-web-ui/src/views/metadata/components/options/index.tsx
@@ -41,11 +41,12 @@ export default defineComponent({
         key: 'value',
       },
       {
-        title: 'Operation',
+        title: () => <div style={{ paddingRight: '40px' }}>Operation</div>,
         key: 'operation',
+        align: 'right',
         render(rowData) {
           return (
-            <n-space>
+            <n-space style="justify-content: flex-end; padding-right: 31px;">
               <OptionsEditForm onConfirm={onFetchData} option={rowData} />
               <n-popconfirm onPositiveClick={() => onDeleteOption(rowData?.key)}>
                 {{

--- a/paimon-web-ui/src/views/metadata/components/options/index.tsx
+++ b/paimon-web-ui/src/views/metadata/components/options/index.tsx
@@ -41,7 +41,7 @@ export default defineComponent({
         key: 'value',
       },
       {
-        title: () => <div style={{ paddingRight: '6px' }}>Operation</div>,
+        title: 'Operation',
         key: 'operation',
         align: 'right',
         render(rowData) {

--- a/paimon-web-ui/src/views/metadata/components/options/index.tsx
+++ b/paimon-web-ui/src/views/metadata/components/options/index.tsx
@@ -41,12 +41,12 @@ export default defineComponent({
         key: 'value',
       },
       {
-        title: () => <div style={{ paddingRight: '40px' }}>Operation</div>,
+        title: () => <div style={{ paddingRight: '6px' }}>Operation</div>,
         key: 'operation',
         align: 'right',
         render(rowData) {
           return (
-            <n-space style="justify-content: flex-end; padding-right: 31px;">
+            <n-space justify="end">
               <OptionsEditForm onConfirm={onFetchData} option={rowData} />
               <n-popconfirm onPositiveClick={() => onDeleteOption(rowData?.key)}>
                 {{


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/299

### Purpose

Optimize the display position of option page fields.

Before:
![image](https://github.com/apache/paimon-webui/assets/34889415/e3cc34d5-8809-40d6-949c-a9fdf2a350a6)

After:
![image](https://github.com/apache/paimon-webui/assets/34889415/7cec88a2-d8ae-4061-b3a9-2b2f4b17a421)



### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
