### PR TITLE
 [Improvement] Adapt width of the created table page to avoid scroll bars

### DIFF
--- a/paimon-web-ui/src/views/metadata/components/table-form/index.tsx
+++ b/paimon-web-ui/src/views/metadata/components/table-form/index.tsx
@@ -145,7 +145,7 @@ export default defineComponent({
           </n-icon>
         </n-button>
         <n-modal v-model:show={this.showModal} mask-closable={false}>
-          <n-card bordered={false} title={this.t('metadata.create_table')} style="width: 1100px">
+          <n-card bordered={false} title={this.t('metadata.create_table')} style="width: 1110px">
             {{
               default: () => (
                 <n-form ref="formRef" rules={this.rules} model={this.formValue}>


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/305

### Purpose

Adjust the width of the created table page to avoid scroll bars

Before:
![image](https://github.com/apache/paimon-webui/assets/34889415/a62f76b5-8cf9-4712-bd80-e1a59b0d41f1)

After:
![image](https://github.com/apache/paimon-webui/assets/34889415/ffc17af4-4668-49ee-9185-94eb0498dd56)

