### PR TITLE
[Bugfix] Add updateTime field into Mapper

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/configrue/MybatisPlusMetaObjectHandler.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/configrue/MybatisPlusMetaObjectHandler.java
@@ -32,6 +32,7 @@ public class MybatisPlusMetaObjectHandler implements MetaObjectHandler {
     @Override
     public void insertFill(MetaObject metaObject) {
         this.strictInsertFill(metaObject, "createTime", LocalDateTime.class, LocalDateTime.now());
+        this.strictUpdateFill(metaObject, "updateTime", LocalDateTime.class, LocalDateTime.now());
     }
 
     @Override

--- a/paimon-web-server/src/main/resources/mapper/SysRoleMapper.xml
+++ b/paimon-web-server/src/main/resources/mapper/SysRoleMapper.xml
@@ -36,7 +36,7 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 	
 	<sql id="selectRoleVo">
 	    select distinct r.id, r.role_name, r.role_key, r.sort,
-            r.enabled, r.is_delete, r.create_time, r.remark
+            r.enabled, r.is_delete, r.create_time, r.update_time, r.remark
         from sys_role r
 	        left join user_role urole on urole.role_id = r.id
 	        left join user u on u.id = urole.user_id

--- a/paimon-web-server/src/main/resources/mapper/UserMapper.xml
+++ b/paimon-web-server/src/main/resources/mapper/UserMapper.xml
@@ -63,7 +63,7 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 	
 	<sql id="selectUserVo">
         select u.id, u.username, u.nickname, u.user_type, u.email, u.url, u.mobile, u.password, u.is_delete, u.enabled, u.create_time,
-        r.id, r.role_name, r.role_key, r.sort, r.enabled as role_status
+        u.update_time, r.id, r.role_name, r.role_key, r.sort, r.enabled as role_status
         from user u
 		    left join user_role urole on u.id = urole.user_id
 		    left join sys_role r on r.id = urole.role_id

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/SysRoleControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/SysRoleControllerTest.java
@@ -97,6 +97,8 @@ public class SysRoleControllerTest extends ControllerTestBase {
                 ObjectMapperUtils.fromJSON(responseString, new TypeReference<R<SysRole>>() {});
         assertEquals(200, r.getCode());
         assertNotNull(r.getData());
+        assertNotNull(r.getData().getCreateTime());
+        assertNotNull(r.getData().getUpdateTime());
         assertEquals(r.getData().getRoleName(), roleName);
     }
 
@@ -189,6 +191,8 @@ public class SysRoleControllerTest extends ControllerTestBase {
         assertEquals(1, firstRole.getSort());
         assertTrue(firstRole.getEnabled());
         assertFalse(firstRole.getIsDelete());
+        assertNotNull(firstRole.getCreateTime());
+        assertNotNull(firstRole.getUpdateTime());
 
         SysRole secondRole = r.getData().get(1);
         assertEquals(2, secondRole.getId());
@@ -197,14 +201,18 @@ public class SysRoleControllerTest extends ControllerTestBase {
         assertEquals(2, secondRole.getSort());
         assertTrue(secondRole.getEnabled());
         assertFalse(secondRole.getIsDelete());
+        assertNotNull(secondRole.getCreateTime());
+        assertNotNull(secondRole.getUpdateTime());
 
         SysRole thirdRole = r.getData().get(2);
         assertEquals(3, thirdRole.getId());
         assertEquals("test-edit", thirdRole.getRoleName());
         assertEquals("test-edit", thirdRole.getRoleKey());
         assertEquals(3, thirdRole.getSort());
-        assertTrue(secondRole.getEnabled());
-        assertFalse(secondRole.getIsDelete());
+        assertTrue(thirdRole.getEnabled());
+        assertFalse(thirdRole.getIsDelete());
+        assertNotNull(thirdRole.getCreateTime());
+        assertNotNull(thirdRole.getUpdateTime());
     }
 
     @Test

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/UserControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/UserControllerTest.java
@@ -83,6 +83,8 @@ public class UserControllerTest extends ControllerTestBase {
         UserVO user = getUser(userId);
         assertNotNull(user);
         assertEquals(user.getUsername(), username);
+        assertNotNull(user.getCreateTime());
+        assertNotNull(user.getUpdateTime());
     }
 
     @Test
@@ -190,6 +192,8 @@ public class UserControllerTest extends ControllerTestBase {
         assertEquals("Admin", firstUser.getNickname());
         assertEquals("admin@paimon.com", firstUser.getEmail());
         assertEquals("LOCAL", firstUser.getUserType());
+        assertNotNull(firstUser.getCreateTime());
+        assertNotNull(firstUser.getUpdateTime());
         assertTrue(firstUser.getEnabled());
 
         UserVO secondUser = r.getData().get(1);
@@ -197,6 +201,8 @@ public class UserControllerTest extends ControllerTestBase {
         assertEquals("common", secondUser.getNickname());
         assertEquals("common@paimon.com", secondUser.getEmail());
         assertEquals("LOCAL", secondUser.getUserType());
+        assertNotNull(secondUser.getCreateTime());
+        assertNotNull(secondUser.getUpdateTime());
         assertTrue(secondUser.getEnabled());
     }
 


### PR DESCRIPTION
Issue: #312 

### Purpose

1.  Fix the issue where the update time field on the user management list page and role management list page is displayed as null.
2.  Fix the updateTime field being null when inserting data.

### Tests

- `SysRoleControllerTest#testQueryRole`
- `SysRoleControllerTest#getRoleList`
- `UserControllerTest#getUser`
- `UserControllerTest#testListUsers`

### API and Format

No.

### Documentation

No.