### PR TITLE
[Bugfix] Support stopping getting job status with scheduling task

### DIFF
--- a/paimon-web-ui/src/views/playground/components/query/components/debugger/index.tsx
+++ b/paimon-web-ui/src/views/playground/components/query/components/debugger/index.tsx
@@ -191,6 +191,7 @@ export default defineComponent({
           message.success(t('playground.job_submission_successfully'))
           jobStore.setCurrentJob(response.data)
           mittBus.emit('jobResult', response.data)
+          mittBus.emit('getStatus')
         }
         else {
           message.error(`${t('playground.job_submission_failed')}`)

--- a/paimon-web-ui/src/views/playground/components/query/index.tsx
+++ b/paimon-web-ui/src/views/playground/components/query/index.tsx
@@ -102,6 +102,9 @@ export default defineComponent({
     const getJobStatusIntervalId = ref<number | undefined>()
 
     const startGetJobStatus = () => {
+      if (getJobStatusIntervalId.value)
+        clearInterval(getJobStatusIntervalId.value)
+
       getJobStatusIntervalId.value = setInterval(async () => {
         if (currentJob.value && currentJob.value.jobId) {
           const response = await getJobStatus(currentJob.value.jobId)

--- a/paimon-web-ui/src/views/playground/components/query/index.tsx
+++ b/paimon-web-ui/src/views/playground/components/query/index.tsx
@@ -101,7 +101,7 @@ export default defineComponent({
 
     const getJobStatusIntervalId = ref<number | undefined>()
 
-    onMounted(() => {
+    const startGetJobStatus = () => {
       getJobStatusIntervalId.value = setInterval(async () => {
         if (currentJob.value && currentJob.value.jobId) {
           const response = await getJobStatus(currentJob.value.jobId)
@@ -109,6 +109,18 @@ export default defineComponent({
             jobStore.setJobStatus(response.data.status)
         }
       }, 1000)
+    }
+
+    const stopGetJobStatus = () => {
+      if (getJobStatusIntervalId.value)
+        clearInterval(getJobStatusIntervalId.value)
+    }
+
+    mittBus.on('getStatus', () => startGetJobStatus())
+
+    watch(jobStatus, (jobStatus) => {
+      if (jobStatus === 'FINISHED' || jobStatus === 'CANCELED' || jobStatus === 'FAILED')
+        stopGetJobStatus()
     })
 
     let computeExecutionTimeIntervalId: number

--- a/paimon-web-ui/src/views/playground/components/query/index.tsx
+++ b/paimon-web-ui/src/views/playground/components/query/index.tsx
@@ -101,10 +101,13 @@ export default defineComponent({
 
     const getJobStatusIntervalId = ref<number | undefined>()
 
-    const startGetJobStatus = () => {
+    const stopGetJobStatus = () => {
       if (getJobStatusIntervalId.value)
         clearInterval(getJobStatusIntervalId.value)
+    }
 
+    const startGetJobStatus = () => {
+      stopGetJobStatus()
       getJobStatusIntervalId.value = setInterval(async () => {
         if (currentJob.value && currentJob.value.jobId) {
           const response = await getJobStatus(currentJob.value.jobId)
@@ -112,11 +115,6 @@ export default defineComponent({
             jobStore.setJobStatus(response.data.status)
         }
       }, 1000)
-    }
-
-    const stopGetJobStatus = () => {
-      if (getJobStatusIntervalId.value)
-        clearInterval(getJobStatusIntervalId.value)
     }
 
     mittBus.on('getStatus', () => startGetJobStatus())


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/333

### Purpose

The front-end obtains the job status scheduled task without a stop method, and it will continue to schedule and request the back-end interface, which is unreasonable.This PR adds a stop method for the scheduled task that obtains the job status on the front end.

According to the data printed by the browser console, the modification of this PR can work.

![微信截图_20240610232019](https://github.com/apache/paimon-webui/assets/34889415/c19d3342-9b05-445a-a8f0-2bfb9391a48e)

