### PR TITLE
[Improvement] Get the logged in user's id from the so-token context 

### DIFF
--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/SessionControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/SessionControllerTest.java
@@ -134,7 +134,6 @@ public class SessionControllerTest extends FlinkSQLGatewayTestBase {
                 mockMvc.perform(
                                 MockMvcRequestBuilders.post(sessionPath + "/create")
                                         .cookie(cookie)
-                                        .param("uid", "1")
                                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                                         .accept(MediaType.APPLICATION_JSON_VALUE))
                         .andExpect(MockMvcResultMatchers.status().isOk())
@@ -159,7 +158,6 @@ public class SessionControllerTest extends FlinkSQLGatewayTestBase {
                 mockMvc.perform(
                                 MockMvcRequestBuilders.post(sessionPath + "/drop")
                                         .cookie(cookie)
-                                        .param("uid", "1")
                                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                                         .accept(MediaType.APPLICATION_JSON_VALUE))
                         .andExpect(MockMvcResultMatchers.status().isOk())


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/366

### Purpose

Get the logged in user's id from the so-token context .

### Tests

- `SessionControllerTest#testCreateSession`
- `SessionControllerTest#testDropSession`