### PR TITLE
[Improvement] Optimize the display of debugger bar

### DIFF
--- a/paimon-web-ui/src/views/playground/components/query/components/console/index.tsx
+++ b/paimon-web-ui/src/views/playground/components/query/components/console/index.tsx
@@ -81,7 +81,7 @@ export default defineComponent({
           pane-style="padding: 0px;box-sizing: border-box;"
         >
           <n-tab-pane name="logs" tab={this.t('playground.logs')}>
-            {this.t('playground.logs')}
+            {/* {this.t('playground.logs')} */}
           </n-tab-pane>
           <n-tab-pane name="result" tab={this.t('playground.result')}>
             <TableActionBar />

--- a/paimon-web-ui/src/views/playground/components/query/index.tsx
+++ b/paimon-web-ui/src/views/playground/components/query/index.tsx
@@ -182,7 +182,10 @@ export default defineComponent({
                     <EditorTabs />
                   </div>
                   <div class={styles.debugger}>
-                    <EditorDebugger tabData={this.tabData} onHandleFormat={this.handleFormat} onHandleSave={this.editorSave} />
+                    {
+                      this.tabData.panelsList?.length > 0
+                      && (<EditorDebugger tabData={this.tabData} onHandleFormat={this.handleFormat} onHandleSave={this.editorSave} />)
+                    }
                   </div>
                   <n-split direction="vertical" max={0.60} min={0.00} resize-trigger-size={0} default-size={0.6}>
                     {{


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/368

### Purpose

Optimize the display of debugger bar, it will only be displayed after clicking the + sign.

Before:

![image](https://github.com/apache/paimon-webui/assets/34889415/f9143c57-2b22-421d-b1c0-2603729b6c6d)


After:

![image](https://github.com/apache/paimon-webui/assets/34889415/966853d1-9946-4560-adca-72ac80360709)

