### PR TITLE
[Bugfix] Fix routing errors

### DIFF
--- a/paimon-web-ui/src/router/index.ts
+++ b/paimon-web-ui/src/router/index.ts
@@ -19,12 +19,12 @@ import {
   type NavigationGuardNext,
   type RouteLocationNormalized,
   createRouter,
-  createWebHistory,
+  createWebHashHistory,
 } from 'vue-router'
 import routes from './routes'
 
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHashHistory(),
   routes,
 })
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

close #372 

Front-end routing configuration mistake: the import.meta.env.BASE_URL always stays as /, resulting in incorrect page rendering.

```ts
const router = createRouter({
  history: createWebHistory(import.meta.env.BASE_URL),
  routes,
})
```
<img width="1753" alt="image" src="https://github.com/apache/paimon-webui/assets/35210666/dda139a8-e95b-43be-a58d-f103f75c7d54">