### PR TITLE
[Impovement] Support start.sh script deployment in daemon

### DIFF
--- a/paimon-web-server/src/main/bin/start.sh
+++ b/paimon-web-server/src/main/bin/start.sh
@@ -51,7 +51,7 @@ while [[ $# -gt 0 ]]; do
       DAEMON=true
       ;;
     *)
-      echo "Unknown parameter: $1"
+      echo "Unsupported parameter: $1"
       exit 1
       ;;
   esac
@@ -63,7 +63,7 @@ if [ "$DAEMON" = true ]; then
     -cp "$PAIMON_UI_HOME/conf:$PAIMON_UI_HOME/libs/*" \
     org.apache.paimon.web.server.PaimonWebServerApplication \
     > /dev/null 2>&1 &
-  echo "Paimon Web Server started in the background."
+  echo "Paimon Web Server started in daemon."
 else
   $JAVA_HOME/bin/java $JAVA_OPTS \
     -cp "$PAIMON_UI_HOME/conf:$PAIMON_UI_HOME/libs/*" \

--- a/paimon-web-server/src/main/bin/start.sh
+++ b/paimon-web-server/src/main/bin/start.sh
@@ -44,6 +44,28 @@ if [ -z "$ACTION_JAR_PATH" ]; then
     echo "ACTION_JAR_PATH is null, CDC cannot be used normally!"
 fi
 
-$JAVA_HOME/bin/java $JAVA_OPTS \
-  -cp "$PAIMON_UI_HOME/conf":"$PAIMON_UI_HOME/libs/*" \
-   org.apache.paimon.web.server.PaimonWebServerApplication
+DAEMON=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --daemon)
+      DAEMON=true
+      ;;
+    *)
+      echo "Unknown parameter: $1"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [ "$DAEMON" = true ]; then
+  nohup $JAVA_HOME/bin/java $JAVA_OPTS \
+    -cp "$PAIMON_UI_HOME/conf:$PAIMON_UI_HOME/libs/*" \
+    org.apache.paimon.web.server.PaimonWebServerApplication \
+    > /dev/null 2>&1 &
+  echo "Paimon Web Server started in the background."
+else
+  $JAVA_HOME/bin/java $JAVA_OPTS \
+    -cp "$PAIMON_UI_HOME/conf:$PAIMON_UI_HOME/libs/*" \
+    org.apache.paimon.web.server.PaimonWebServerApplication
+fi


### PR DESCRIPTION
Close #379.
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Support the `start.sh` script to support daemon deployment.

Daemon deployment. Run bin/start.sh --daemon
<img width="1114" alt="image" src="https://github.com/apache/paimon-webui/assets/35210666/d45f824e-353c-4ee9-a134-68671a83a98f">


Foreground deployment. Run bin/start.sh
<img width="1579" alt="image" src="https://github.com/apache/paimon-webui/assets/35210666/d9524dfd-1f1e-44c9-857e-675ee90832a5">
