### PR TITLE
[Feature] Support scheduled tasks for frontend

### DIFF
--- a/paimon-web-ui/src/api/models/session/index.ts
+++ b/paimon-web-ui/src/api/models/session/index.ts
@@ -1,0 +1,25 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. */
+
+import httpRequest from '../../request'
+
+/**
+ * # Create a session
+ */
+export function createSession() {
+  return httpRequest.post('/session/create')
+}


### PR DESCRIPTION
Close: #331

### Purpose

Support scheduled tasks for frontend.

The task status displayed on the page changes, indicating that the scheduled task to refresh the task status is working.

![image](https://github.com/apache/paimon-webui/assets/34889415/b27f8631-311b-45db-b8cc-3430501bf0b4)

Printing from the console can also verify that the scheduled task can work.

![image](https://github.com/apache/paimon-webui/assets/34889415/1d90b36a-a754-4410-bfc0-521b69f8b330)

Create a session scheduled task print.

![image](https://github.com/apache/paimon-webui/assets/34889415/f4a5b503-318f-4aaa-a6ad-cca55b4333fc)

