### PR TITLE
[Improvement] Adjust the header toolbar to be centered vertically

### DIFF
--- a/paimon-web-ui/src/layouts/content/components/toolbar/index.tsx
+++ b/paimon-web-ui/src/layouts/content/components/toolbar/index.tsx
@@ -139,7 +139,7 @@ export default defineComponent({
   },
   render() {
     return (
-      <n-space align="center" size={20}>
+      <n-space align="center" size={20} item-style="display: flex; align-items: center">
         <n-popover
           trigger="hover"
           placement="bottom"


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/420

### Purpose

Adjust the header toolbar to be centered vertically.

![image](https://github.com/apache/paimon-webui/assets/34889415/70063d25-cfb9-4473-988c-55d97aae67b3)

