### PR TITLE
[Bugfix] Unify global LocalDateTime format

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/configrue/JacksonConfig.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/configrue/JacksonConfig.java
@@ -23,18 +23,21 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
-import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /** JacksonConfig. */
 @Configuration
 public class JacksonConfig {
     @Bean
-    public ObjectMapper getJacksonObjectMapper(Jackson2ObjectMapperBuilder builder) {
-        ObjectMapper objectMapper = builder.createXmlMapper(false).build();
+    public ObjectMapper getJacksonObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
         // When the sequence is changed to json, all longs will be changed to strings.
         // Because the numeric type in js cannot contain all java long values, precision will be
         // lost after more than 16 digits.
@@ -47,7 +50,14 @@ public class JacksonConfig {
         // If there are more attributes during deserialization, no exception will be thrown.
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         // Date format handling.
-        objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
+        JavaTimeModule javaTimeModule = new JavaTimeModule();
+        javaTimeModule.addSerializer(
+                LocalDateTime.class,
+                new LocalDateTimeSerializer(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        javaTimeModule.addDeserializer(
+                LocalDateTime.class,
+                new LocalDateTimeDeserializer(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        objectMapper.registerModule(javaTimeModule);
         objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
         return objectMapper;
     }

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/configurer/JacksonConfigTests.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/configurer/JacksonConfigTests.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.web.server.configurer;
 
+import org.apache.paimon.web.server.configrue.JacksonConfig;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +31,7 @@ import java.time.LocalDateTime;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+/** Test for {@link JacksonConfig}. */
 @SpringBootTest
 public class JacksonConfigTests {
 

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/configurer/JacksonConfigTests.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/configurer/JacksonConfigTests.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.web.server.configurer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+public class JacksonConfigTests {
+
+    @Autowired private ObjectMapper objectMapper;
+
+    private static final String TIME_FORMATTED_JSON_STR = "\"2024-06-26 13:01:30\"";
+    private static final String TIME_UNFORMATTED_JSON_STR = "\"2024-06-26T13:01:30Z\"";
+
+    @Test
+    public void testLocalDateTimeSerialization() throws IOException {
+        LocalDateTime dateTime = LocalDateTime.of(2024, 6, 26, 13, 1, 30);
+        String json = objectMapper.writeValueAsString(dateTime);
+        assertEquals(TIME_FORMATTED_JSON_STR, json);
+    }
+
+    @Test
+    public void testLocalDateTimeDeserialization() throws IOException {
+        LocalDateTime dateTime =
+                objectMapper.readValue(TIME_FORMATTED_JSON_STR, LocalDateTime.class);
+        assertEquals(LocalDateTime.of(2024, 6, 26, 13, 1, 30), dateTime);
+    }
+
+    @Test
+    public void testInvalidLocalDateTimeDeserialization() {
+        assertThrows(
+                com.fasterxml.jackson.databind.exc.InvalidFormatException.class,
+                () -> objectMapper.readValue(TIME_UNFORMATTED_JSON_STR, LocalDateTime.class));
+    }
+}


### PR DESCRIPTION
Close: #451 
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Unify global LocalDateTime format

<!-- What is the purpose of the change, or the associated issue -->

### Tests

- `JacksonConfigTests#testLocalDateTimeSerialization`
- `JacksonConfigTests#testLocalDateTimeDeserialization`
- `JacksonConfigTests#testInvalidLocalDateTimeDeserialization`

No.

<!-- List UT and IT cases to verify this change -->

### API and Format
No.

<!-- Does this change affect API or storage format -->

### Documentation
No.

<!-- Does this change introduce a new feature -->
