### PR TITLE
[Improvement] Support indeterminate keys with the permission configuration of role creation

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/data/model/SysRole.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/data/model/SysRole.java
@@ -63,6 +63,10 @@ public class SysRole extends BaseModel {
     @NotEmpty(message = "invalid.menuIds")
     private Integer[] menuIds;
 
+    /** indeterminate keys. */
+    @TableField(exist = false)
+    private Integer[] indeterminateKeys;
+
     /** Role menu permissions. */
     @TableField(exist = false)
     private Set<String> permissions;

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/SysRoleServiceImpl.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/SysRoleServiceImpl.java
@@ -195,20 +195,30 @@ public class SysRoleServiceImpl extends ServiceImpl<SysRoleMapper, SysRole>
      * @param role role info
      */
     public int insertRoleMenu(SysRole role) {
+        Integer[] mergedMenuIds = mergeMenuIds(role.getMenuIds(), role.getIndeterminateKeys());
         int rows = 1;
-        if (role.getMenuIds() != null && role.getMenuIds().length > 0) {
+        if (mergedMenuIds.length > 0) {
             List<RoleMenu> list = new ArrayList<RoleMenu>();
-            for (Integer menuId : role.getMenuIds()) {
+            for (Integer menuId : mergedMenuIds) {
                 RoleMenu rm = new RoleMenu();
                 rm.setRoleId(role.getId());
                 rm.setMenuId(menuId);
                 list.add(rm);
             }
-            if (list.size() > 0) {
-                rows = roleMenuMapper.batchRoleMenu(list);
-            }
+            rows = roleMenuMapper.batchRoleMenu(list);
         }
         return rows;
+    }
+
+    private Integer[] mergeMenuIds(Integer[] menuIds, Integer[] indeterminateKeys) {
+        Set<Integer> mergedSet = new HashSet<>();
+        if (menuIds != null) {
+            mergedSet.addAll(Arrays.asList(menuIds));
+        }
+        if (indeterminateKeys != null) {
+            mergedSet.addAll(Arrays.asList(indeterminateKeys));
+        }
+        return mergedSet.toArray(new Integer[0]);
     }
 
     /**


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/472

### Purpose

The back end adds indeterminate keys to the permission configuration of role creation.