### PR TITLE
[Improvement] The query module obtains the cluster name through deploymentMode

### DIFF
--- a/paimon-web-ui/src/api/models/cluster/index.ts
+++ b/paimon-web-ui/src/api/models/cluster/index.ts
@@ -32,9 +32,9 @@ export function getClusterList() {
 /**
  * # List Cluster by ClusterType
  */
-export function getClusterListByType(type: string, pageNum: number, pageSize: number) {
+export function getClusterListByType(deploymentMode: string, pageNum: number, pageSize: number) {
   return httpRequest.get('/cluster/list', {
-    type,
+    deploymentMode,
     pageNum,
     pageSize,
   })

--- a/paimon-web-ui/src/api/models/cluster/index.ts
+++ b/paimon-web-ui/src/api/models/cluster/index.ts
@@ -41,6 +41,17 @@ export function getClusterListByDeploymentMode(deploymentMode: string, pageNum: 
 }
 
 /**
+ * # List Cluster by Type
+ */
+export function getClusterListByType(type: string, pageNum: number, pageSize: number) {
+  return httpRequest.get('/cluster/list', {
+    type,
+    pageNum,
+    pageSize,
+  })
+}
+
+/**
  * # Create Cluster
  */
 export function createCluster() {

--- a/paimon-web-ui/src/api/models/cluster/index.ts
+++ b/paimon-web-ui/src/api/models/cluster/index.ts
@@ -30,9 +30,9 @@ export function getClusterList() {
 }
 
 /**
- * # List Cluster by ClusterType
+ * # List Cluster by Deployment Mode
  */
-export function getClusterListByType(deploymentMode: string, pageNum: number, pageSize: number) {
+export function getClusterListByDeploymentMode(deploymentMode: string, pageNum: number, pageSize: number) {
   return httpRequest.get('/cluster/list', {
     deploymentMode,
     pageNum,

--- a/paimon-web-ui/src/views/playground/components/query/components/debugger/index.tsx
+++ b/paimon-web-ui/src/views/playground/components/query/components/debugger/index.tsx
@@ -72,9 +72,9 @@ export default defineComponent({
         { label: 'Limit 100 items', key: '100' },
         { label: 'Limit 1000 items', key: '1000' },
       ],
-      conditionValue: 'flink-sql-gateway',
+      conditionValue: 'Flink',
       bigDataOptions: [
-        { label: 'Flink', value: 'flink-sql-gateway' },
+        { label: 'Flink', value: 'Flink' },
         { label: 'Spark', value: 'Spark' },
       ],
       conditionValue2: '',
@@ -153,7 +153,8 @@ export default defineComponent({
     }
 
     function getClusterData() {
-      getClusterListByType(debuggerVariables.conditionValue, 1, Number.MAX_SAFE_INTEGER).then((response) => {
+      const deploymentMode = debuggerVariables.conditionValue === 'Flink' ? 'flink-sql-gateway' : debuggerVariables.conditionValue
+      getClusterListByType(deploymentMode, 1, Number.MAX_SAFE_INTEGER).then((response) => {
         if (response && response.data) {
           const clusterList = response.data as Cluster[]
           debuggerVariables.clusterOptions = clusterList.map(cluster => ({

--- a/paimon-web-ui/src/views/playground/components/query/components/debugger/index.tsx
+++ b/paimon-web-ui/src/views/playground/components/query/components/debugger/index.tsx
@@ -74,7 +74,7 @@ export default defineComponent({
       ],
       conditionValue: 'Flink',
       bigDataOptions: [
-        { label: 'Flink', value: 'Flink' },
+        { label: 'Flink', value: 'flink-sql-gateway' },
         { label: 'Spark', value: 'Spark' },
       ],
       conditionValue2: '',

--- a/paimon-web-ui/src/views/playground/components/query/components/debugger/index.tsx
+++ b/paimon-web-ui/src/views/playground/components/query/components/debugger/index.tsx
@@ -20,7 +20,7 @@ import { FormatAlignLeftOutlined } from '@vicons/material'
 import { NInput, useMessage } from 'naive-ui'
 
 import styles from './index.module.scss'
-import { getClusterListByType } from '@/api/models/cluster'
+import { getClusterListByDeploymentMode } from '@/api/models/cluster'
 import type { Cluster } from '@/api/models/cluster/types'
 import type { JobSubmitDTO } from '@/api/models/job/types/job'
 import { createRecord, stopJob, submitJob } from '@/api/models/job'
@@ -154,7 +154,7 @@ export default defineComponent({
 
     function getClusterData() {
       const deploymentMode = debuggerVariables.conditionValue === 'Flink' ? 'flink-sql-gateway' : debuggerVariables.conditionValue
-      getClusterListByType(deploymentMode, 1, Number.MAX_SAFE_INTEGER).then((response) => {
+      getClusterListByDeploymentMode(deploymentMode, 1, Number.MAX_SAFE_INTEGER).then((response) => {
         if (response && response.data) {
           const clusterList = response.data as Cluster[]
           debuggerVariables.clusterOptions = clusterList.map(cluster => ({

--- a/paimon-web-ui/src/views/playground/components/query/components/debugger/index.tsx
+++ b/paimon-web-ui/src/views/playground/components/query/components/debugger/index.tsx
@@ -72,7 +72,7 @@ export default defineComponent({
         { label: 'Limit 100 items', key: '100' },
         { label: 'Limit 1000 items', key: '1000' },
       ],
-      conditionValue: 'Flink',
+      conditionValue: 'flink-sql-gateway',
       bigDataOptions: [
         { label: 'Flink', value: 'flink-sql-gateway' },
         { label: 'Spark', value: 'Spark' },


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/481

### Purpose

When creating a cluster, deploymentMode is added to distinguish different deployment modes, so the query module obtains the cluster name through deploymentMode.
