### PR TITLE
[Improvement] Support SessionController and JobController obtaining cluster through deployment mode

### DIFF
--- a/paimon-web-server/pom.xml
+++ b/paimon-web-server/pom.xml
@@ -37,6 +37,7 @@ under the License.
     <properties>
         <hadoop.version>2.8.5</hadoop.version>
         <flink.version>1.18.1</flink.version>
+        <scala.version>2.12</scala.version>
     </properties>
 
     <dependencies>
@@ -245,6 +246,13 @@ under the License.
                     <artifactId>commons-cli</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/SessionController.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/controller/SessionController.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.web.server.controller;
 
+import org.apache.paimon.web.gateway.enums.DeploymentMode;
 import org.apache.paimon.web.server.data.dto.SessionDTO;
 import org.apache.paimon.web.server.data.model.ClusterInfo;
 import org.apache.paimon.web.server.data.result.R;
@@ -59,7 +60,7 @@ public class SessionController {
         }
         int uid = StpUtil.getLoginIdAsInt();
         QueryWrapper<ClusterInfo> queryWrapper = new QueryWrapper<>();
-        queryWrapper.eq("type", "Flink");
+        queryWrapper.eq("deployment_mode", DeploymentMode.FLINK_SQL_GATEWAY.getType());
         List<ClusterInfo> clusterInfos = clusterService.list(queryWrapper);
         for (ClusterInfo cluster : clusterInfos) {
             SessionDTO sessionDTO = new SessionDTO();
@@ -85,7 +86,7 @@ public class SessionController {
         }
         int uid = StpUtil.getLoginIdAsInt();
         QueryWrapper<ClusterInfo> queryWrapper = new QueryWrapper<>();
-        queryWrapper.eq("type", "Flink");
+        queryWrapper.eq("deployment_mode", DeploymentMode.FLINK_SQL_GATEWAY.getType());
         List<ClusterInfo> clusterInfos = clusterService.list(queryWrapper);
         for (ClusterInfo cluster : clusterInfos) {
             SessionDTO sessionDTO = new SessionDTO();

--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/JobServiceImpl.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/JobServiceImpl.java
@@ -25,6 +25,7 @@ import org.apache.paimon.web.engine.flink.common.result.FetchResultParams;
 import org.apache.paimon.web.engine.flink.common.status.JobStatus;
 import org.apache.paimon.web.engine.flink.sql.gateway.model.SessionEntity;
 import org.apache.paimon.web.gateway.config.ExecutionConfig;
+import org.apache.paimon.web.gateway.enums.DeploymentMode;
 import org.apache.paimon.web.gateway.enums.EngineType;
 import org.apache.paimon.web.gateway.provider.ExecutorFactoryProvider;
 import org.apache.paimon.web.server.context.LogContextHolder;
@@ -302,8 +303,8 @@ public class JobServiceImpl extends ServiceImpl<JobMapper, JobInfo> implements J
 
         if (taskType.equals("Flink")) {
             QueryWrapper<ClusterInfo> queryWrapper = new QueryWrapper<>();
-            queryWrapper.eq("type", "Flink");
-            List<ClusterInfo> clusters = clusterService.list();
+            queryWrapper.eq("deployment_mode", DeploymentMode.FLINK_SQL_GATEWAY.getType());
+            List<ClusterInfo> clusters = clusterService.list(queryWrapper);
             for (ClusterInfo cluster : clusters) {
                 try {
                     SessionEntity session =

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/JobControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/JobControllerTest.java
@@ -113,6 +113,7 @@ public class JobControllerTest extends FlinkSQLGatewayTestBase {
                         .port(port)
                         .enabled(true)
                         .type("Flink")
+                        .deploymentMode("flink-sql-gateway")
                         .build();
         boolean res = clusterService.save(cluster);
         assertTrue(res);

--- a/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/SessionControllerTest.java
+++ b/paimon-web-server/src/test/java/org/apache/paimon/web/server/controller/SessionControllerTest.java
@@ -123,6 +123,7 @@ public class SessionControllerTest extends FlinkSQLGatewayTestBase {
                         .port(port)
                         .enabled(true)
                         .type("Flink")
+                        .deploymentMode("flink-sql-gateway")
                         .build();
         boolean res = clusterService.save(cluster);
         assertTrue(res);


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/483

### Purpose

When creating a cluster, deploymentMode is added to distinguish different deployment modes, so the query module obtains the cluster name through deploymentMode.

### Tests

- `JobControllerTest#before`
- `SessionControllerTest#testCreateSession`