### PR TITLE
[Improvement] Support indeterminate keys for permission configuration of role creation

### DIFF
--- a/paimon-web-ui/src/api/models/role/types.ts
+++ b/paimon-web-ui/src/api/models/role/types.ts
@@ -55,4 +55,5 @@ export interface RoleDTO {
   enabled: boolean
   remark?: string
   menuIds: number[]
+  indeterminateKeys?: number[]
 }

--- a/paimon-web-ui/src/views/system/role/components/role-form/index.tsx
+++ b/paimon-web-ui/src/views/system/role/components/role-form/index.tsx
@@ -41,6 +41,7 @@ const props = {
       enabled: true,
       remark: '',
       menuIds: [],
+      indeterminateKeys: [],
     }),
   },
   'onUpdate:formValue': [Function, Object] as PropType<((value: RoleDTO) => void) | undefined>,
@@ -95,6 +96,10 @@ export default defineComponent({
       props.formValue.menuIds = checkIds
     }
 
+    const onUpdateIndeterminateKeys = (indeterminateKeys: Array<number>) => {
+      props.formValue.indeterminateKeys = indeterminateKeys
+    }
+
     const handleConfirm = async () => {
       await formRef.value.validate()
       props && props.onConfirm && props.onConfirm()
@@ -109,6 +114,7 @@ export default defineComponent({
         enabled: true,
         remark: '',
         menuIds: [],
+        indeterminateKeys: [],
       })
     }
 
@@ -120,6 +126,7 @@ export default defineComponent({
       handleCloseModal,
       renderLabel,
       onUpdateMenuIds,
+      onUpdateIndeterminateKeys,
       handleConfirm,
       t,
     }
@@ -160,11 +167,13 @@ export default defineComponent({
                 <n-form-item label={this.t('system.role.permission_setting')} path="menuIds">
                   <n-tree
                     key-field="id"
-                    default-expand-all
+                    cascade
                     block-line
                     renderLabel={this.renderLabel}
                     onUpdate:checkedKeys={this.onUpdateMenuIds}
+                    onUpdate:indeterminateKeys={this.onUpdateIndeterminateKeys}
                     checkedKeys={this.formValue.menuIds}
+                    indeterminateKeys={this.formValue.indeterminateKeys}
                     data={this.permissionTree}
                     expand-on-click
                     checkable


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/472

### Purpose

The front end adds indeterminate keys to the permission configuration of role creation.

![image](https://github.com/apache/paimon-webui/assets/34889415/5e242c5c-c43d-4fb6-8cfd-077ae0d6d442)

![image](https://github.com/apache/paimon-webui/assets/34889415/a4c4401b-0be2-40e2-b826-ec523dbf00e2)

