### PR TITLE
[Improvement] Remove unnecessary logging of cluster interface

### DIFF
--- a/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/ClusterServiceImpl.java
+++ b/paimon-web-server/src/main/java/org/apache/paimon/web/server/service/impl/ClusterServiceImpl.java
@@ -93,9 +93,6 @@ public class ClusterServiceImpl extends ServiceImpl<ClusterMapper, ClusterInfo>
         QueryWrapper<ClusterInfo> queryWrapper =
                 new QueryWrapper<ClusterInfo>().eq("enabled", true);
         for (ClusterInfo clusterInfo : clusterMapper.selectList(queryWrapper)) {
-            log.info(
-                    "Starting a scheduled job to check cluster: `{}` status ...",
-                    clusterInfo.getClusterName());
             if (EngineType.SPARK.name().equals(clusterInfo.getType().toUpperCase())) {
                 log.warn(
                         "Current engine type: {} doesn't support checking Cluster status.",


### PR DESCRIPTION
close: https://github.com/apache/paimon-webui/issues/490

### Purpose

The checkClusterHeartbeatStatus method in the cluster interface prints info logs every 1 minute. This PR removes unnecessary log printing in the cluster interface.