### PR TITLE
[Release] Support releasing scripts of Paimon WebUI

### DIFF
--- a/tools/releasing/create_release_branch.sh
+++ b/tools/releasing/create_release_branch.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Variables with defaults (if not overwritten by environment)
+##
+RELEASE_CANDIDATE=${RELEASE_CANDIDATE:-none}
+
+##
+## Required variables
+##
+RELEASE_VERSION=${RELEASE_VERSION}
+
+if [ -z "${RELEASE_VERSION}" ]; then
+	echo "RELEASE_VERSION was not set"
+	exit 1
+fi
+
+# fail immediately
+set -o errexit
+set -o nounset
+
+CURR_DIR=`pwd`
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PROJECT_ROOT="${BASE_DIR}/../../"
+
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should aways exist in project root
+if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
+    echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
+    exit 1
+fi
+
+###########################
+
+TARGET_BRANCH=release-${RELEASE_VERSION}
+if [ "${RELEASE_CANDIDATE}" != "none" ]; then
+  TARGET_BRANCH=${TARGET_BRANCH}-rc${RELEASE_CANDIDATE}
+fi
+
+cd ${PROJECT_ROOT}
+git checkout -b ${TARGET_BRANCH}
+
+RELEASE_COMMIT_HASH=`git rev-parse HEAD`
+echo "Done. Created a new release branch with commit hash ${RELEASE_COMMIT_HASH}."
+
+cd ${CURR_DIR}

--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Variables with defaults (if not overwritten by environment)
+##
+MVN=${MVN:-mvn}
+
+##
+## Required variables
+##
+RELEASE_VERSION=${RELEASE_VERSION}
+
+if [ -z "${RELEASE_VERSION}" ]; then
+	echo "RELEASE_VERSION is unset"
+	exit 1
+fi
+
+# fail immediately
+set -o errexit
+set -o nounset
+
+CURR_DIR=`pwd`
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PROJECT_ROOT="$( cd "$( dirname "${BASE_DIR}/../../../" )" >/dev/null && pwd )"
+
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should aways exist in project root
+if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
+    echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
+    exit 1
+fi
+
+if [ "$(uname)" == "Darwin" ]; then
+    SHASUM="shasum -a 512"
+else
+    SHASUM="sha512sum"
+fi
+
+###########################
+
+RELEASE_DIR=${PROJECT_ROOT}/release
+CLONE_DIR=${RELEASE_DIR}/paimon-webui-tmp-clone
+
+rm -rf ${RELEASE_DIR}
+mkdir ${RELEASE_DIR}
+
+# delete the temporary release directory on error
+trap 'rm -rf ${RELEASE_DIR}' ERR
+
+echo "Creating source package"
+
+# create a temporary git clone to ensure that we have a pristine source release
+git clone ${PROJECT_ROOT} ${CLONE_DIR}
+
+cd ${CLONE_DIR}
+rsync -a \
+  --exclude ".git" --exclude ".gitignore" \
+  --exclude ".asf.yaml" \
+  --exclude "target" \
+  --exclude ".idea" --exclude "*.iml" \
+  --exclude ".travis.yml" \
+  . paimon-webui-${RELEASE_VERSION}
+
+tar czf ${RELEASE_DIR}/apache-paimon-webui-${RELEASE_VERSION}-src.tgz paimon-webui-${RELEASE_VERSION}
+gpg --armor --detach-sig ${RELEASE_DIR}/apache-paimon-webui-${RELEASE_VERSION}-src.tgz
+cd ${RELEASE_DIR}
+${SHASUM} apache-paimon-webui-${RELEASE_VERSION}-src.tgz > apache-paimon-webui-${RELEASE_VERSION}-src.tgz.sha512
+
+rm -rf ${CLONE_DIR}
+
+echo "Done. Source release package and signatures created under ${RELEASE_DIR}/."
+
+cd ${CURR_DIR}

--- a/tools/releasing/deploy_staging_jars.sh
+++ b/tools/releasing/deploy_staging_jars.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Variables with defaults (if not overwritten by environment)
+##
+MVN=${MVN:-mvn}
+CUSTOM_OPTIONS=${CUSTOM_OPTIONS:-}
+
+# fail immediately
+set -o errexit
+set -o nounset
+
+CURR_DIR=`pwd`
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PROJECT_ROOT="${BASE_DIR}/../../"
+
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should always exist in project root
+if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
+    echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
+    exit 1
+fi
+
+###########################
+
+cd ${PROJECT_ROOT}
+
+echo "Deploying to repository.apache.org"
+${MVN} clean deploy -Prelease,apache-release,docs-and-source -DskipTests -DretryFailedDeploymentCount=10 $CUSTOM_OPTIONS
+
+cd ${CURR_DIR}

--- a/tools/releasing/update_branch_version.sh
+++ b/tools/releasing/update_branch_version.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Variables with defaults (if not overwritten by environment)
+##
+MVN=${MVN:-mvn}
+
+##
+## Required variables
+##
+OLD_VERSION=${OLD_VERSION}
+NEW_VERSION=${NEW_VERSION}
+
+if [ -z "${OLD_VERSION}" ]; then
+    echo "NEW_VERSION was not set."
+    exit 1
+fi
+
+if [ -z "${NEW_VERSION}" ]; then
+    echo "NEW_VERSION was not set."
+    exit 1
+fi
+
+# fail immediately
+set -o errexit
+set -o nounset
+
+CURR_DIR=`pwd`
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PROJECT_ROOT="${BASE_DIR}/../../"
+
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should aways exist in project root
+if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
+    echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
+    exit 1
+fi
+
+###########################
+
+cd ${PROJECT_ROOT}
+
+# change version in all pom files
+mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${NEW_VERSION}
+
+git commit -am "[release] Update version to ${NEW_VERSION}"
+
+NEW_VERSION_COMMIT_HASH=`git rev-parse HEAD`
+
+echo "Done. Created a new commit for the new version ${NEW_VERSION}, with hash ${NEW_VERSION_COMMIT_HASH}"
+echo "If this is a new version to be released (or a candidate to be voted on), don't forget to create a signed release tag on GitHub and push the changes."
+
+cd ${CURR_DIR}


### PR DESCRIPTION
### Purpose

Support releasing scripts of Paimon WebUI to release version. Follow the process of [Creating a Paimon Release](https://cwiki.apache.org/confluence/display/PAIMON/Creating+a+Paimon+Release).

### Tests

No.

### API and Format

No.

### Documentation

No.