### PR TITLE
[Bugfix] Fix start.sh with config path

### DIFF
--- a/paimon-web-server/src/main/bin/start.sh
+++ b/paimon-web-server/src/main/bin/start.sh
@@ -75,12 +75,12 @@ fi
 
 if [ "$DAEMON" = true ]; then
   nohup $JAVA_HOME/bin/java $JAVA_OPTS \
-    -cp "$PAIMON_UI_HOME/conf:$PAIMON_UI_HOME/libs/*" \
+    -cp "$PAIMON_UI_HOME/config:$PAIMON_UI_HOME/libs/*" \
     org.apache.paimon.web.server.PaimonWebServerApplication \
     > /dev/null 2>&1 &
   echo "Paimon Web Server started in daemon."
 else
   $JAVA_HOME/bin/java $JAVA_OPTS \
-    -cp "$PAIMON_UI_HOME/conf:$PAIMON_UI_HOME/libs/*" \
+    -cp "$PAIMON_UI_HOME/config:$PAIMON_UI_HOME/libs/*" \
     org.apache.paimon.web.server.PaimonWebServerApplication
 fi


### PR DESCRIPTION
### Purpose

<!-- What is the purpose of the change, or the associated issue -->

Fix #515.

Change the config path to match the outputDirectory config in the assembly package file

### Tests

<!-- List UT and IT cases to verify this change -->
No

### API and Format

<!-- Does this change affect API or storage format -->
No

### Documentation

<!-- Does this change introduce a new feature -->
No
