### PR TITLE
[Bugfix] Fix getting system environment variables error

### DIFF
--- a/paimon-web-server/src/main/bin/env.sh
+++ b/paimon-web-server/src/main/bin/env.sh
@@ -20,7 +20,7 @@
 FLINK_HOME=${FLINK_HOME:-""}
 
 # Set the ACTION_JAR_PATH to execute the paimon action job.
-ACTION_JAR_PATH=
+ACTION_JAR_PATH=${ACTION_JAR_PATH:-""}
 
 JVM_ARGS="-server"
 

--- a/paimon-web-server/src/main/bin/start.sh
+++ b/paimon-web-server/src/main/bin/start.sh
@@ -64,12 +64,18 @@ fi
 if [ -z "$JAVA_HOME" ]; then
       echo "JAVA_HOME is null, exit..."
       exit 1
+else
+   export JAVA_HOME=$JAVA_HOME
 fi
 if [ -z "$FLINK_HOME" ]; then
     echo "FLINK_HOME is null, CDC cannot be used normally!"
+else
+    export FLINK_HOME=$FLINK_HOME
 fi
 if [ -z "$ACTION_JAR_PATH" ]; then
     echo "ACTION_JAR_PATH is null, CDC cannot be used normally!"
+else
+    export ACTION_JAR_PATH=$ACTION_JAR_PATH
 fi
 
 


### PR DESCRIPTION
… cdc

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
fix bug that "FLINK_HOME is null or ACTION_JAR_PATH is null"  when use cdc.

i had add FLINK_HOME  and ACTION_JAR_PATH in bin/env.sh, but it also throw error .

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
